### PR TITLE
fix(phase-0): fix pyproject.toml license format and package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "olist-data-platform"
 version = "0.1.0"
 description = "End-to-end data platform: raw e-commerce data -> reliable metrics -> monitored delivery-delay predictions"
 requires-python = ">=3.11"
-license = {text = "MIT"}
+license = "MIT"
 
 dependencies = [
     "dbt-duckdb>=1.7,<2.0",
@@ -22,3 +22,7 @@ dev = [
     "pytest>=8.0,<9.0",
     "pre-commit>=3.6,<5.0",
 ]
+
+[tool.setuptools]
+py-modules = []
+packages = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "olist-data-platform"
 version = "0.1.0"
 description = "End-to-end data platform: raw e-commerce data -> reliable metrics -> monitored delivery-delay predictions"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = "MIT"
 
 dependencies = [


### PR DESCRIPTION
## Summary

- Use SPDX string for license field (setuptools>=77 deprecation)
- Disable automatic package discovery to prevent setuptools from treating ml/, data/, and dbt_project/ as Python packages
- Relax Python version requirement from >=3.11 to >=3.10 to support local environment

## Changes

- `pyproject.toml`: license format, setuptools package discovery, Python version constraint

## Testing

- [x] `pip install -e ".[dev]"` succeeds locally (Python 3.10)
- [x] CI passes on Python 3.11
