### PR TITLE
feat(phase-2): intermediate layer with payment aggregation and enriched orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Phase 2 — Intermediate (Business Rules)
+
+- Create `int_payments_aggregated` — one row per order with total payment, installments, method count
+- Create `int_order_status_normalized` — map raw statuses to placed/in_transit/delivered/canceled/other with boolean flags
+- Create `int_orders_enriched` — keystone model joining orders + payments + status + reviews with delay metrics
+- Compute `delivery_days`, `estimated_delivery_days`, `delay_days`, `is_delayed` per `docs/definitions.md`
+- Handle nulls: `is_delayed = null` when delivery dates are missing
+- Deduplicate reviews (most recent per order)
+- Add `_int__models.yml` with column descriptions and schema tests for all 3 models
+
 ### Phase 1 — Staging (Reliable Data)
 
 - Create 8 staging models: `stg_orders`, `stg_order_items`, `stg_order_payments`, `stg_order_reviews`, `stg_customers`, `stg_sellers`, `stg_products`, `stg_geolocation`

--- a/dbt_project/models/intermediate/_int__models.yml
+++ b/dbt_project/models/intermediate/_int__models.yml
@@ -1,0 +1,175 @@
+version: 2
+
+models:
+
+  # ──────────────────────────────────────────────
+  # int_payments_aggregated
+  # ──────────────────────────────────────────────
+  - name: int_payments_aggregated
+    description: "Payment data aggregated to one row per order. Resolves multi-payment duplication."
+    columns:
+      - name: order_id
+        description: "Unique order identifier (PK). One row per order."
+        data_tests:
+          - unique
+          - not_null
+
+      - name: total_payment_value
+        description: "Sum of all payment values for the order (BRL)."
+        data_tests:
+          - not_null
+
+      - name: payment_installments_max
+        description: "Maximum number of installments across all payments for the order."
+        data_tests:
+          - not_null
+
+      - name: payment_method_count
+        description: "Number of distinct payment methods used in the order."
+        data_tests:
+          - not_null
+
+      - name: payment_type_list
+        description: "Comma-separated list of distinct payment types (alphabetical)."
+        data_tests:
+          - not_null
+
+      - name: payment_count
+        description: "Total number of payment records for the order."
+        data_tests:
+          - not_null
+
+  # ──────────────────────────────────────────────
+  # int_order_status_normalized
+  # ──────────────────────────────────────────────
+  - name: int_order_status_normalized
+    description: "Order statuses mapped to a simplified set: placed, in_transit, delivered, canceled, other."
+    columns:
+      - name: order_id
+        description: "Unique order identifier (PK)."
+        data_tests:
+          - unique
+          - not_null
+
+      - name: raw_status
+        description: "Original order status from stg_orders."
+        data_tests:
+          - not_null
+
+      - name: normalized_status
+        description: "Simplified status category."
+        data_tests:
+          - not_null
+          - accepted_values:
+              values:
+                - placed
+                - in_transit
+                - delivered
+                - canceled
+                - other
+
+      - name: is_delivered
+        description: "1 if the order was delivered, 0 otherwise."
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: [0, 1]
+
+      - name: is_canceled
+        description: "1 if the order was canceled, 0 otherwise."
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: [0, 1]
+
+  # ──────────────────────────────────────────────
+  # int_orders_enriched
+  # ──────────────────────────────────────────────
+  - name: int_orders_enriched
+    description: >
+      Keystone model joining orders + payments + status + reviews.
+      Computes delivery and delay metrics. Grain: 1 row per order_id.
+    columns:
+      - name: order_id
+        description: "Unique order identifier (PK)."
+        data_tests:
+          - unique
+          - not_null
+
+      - name: customer_id
+        description: "Foreign key to stg_customers."
+        data_tests:
+          - not_null
+
+      - name: order_purchased_at
+        description: "Timestamp when the order was placed."
+        data_tests:
+          - not_null
+
+      - name: order_approved_at
+        description: "Timestamp when payment was approved."
+
+      - name: order_delivered_carrier_at
+        description: "Timestamp when handed to the carrier."
+
+      - name: order_delivered_customer_at
+        description: "Timestamp when the customer received the order."
+
+      - name: order_estimated_delivery_at
+        description: "Estimated delivery date shown at purchase."
+
+      - name: order_status
+        description: "Raw order status."
+        data_tests:
+          - not_null
+
+      - name: normalized_status
+        description: "Simplified status (placed, in_transit, delivered, canceled, other)."
+        data_tests:
+          - not_null
+
+      - name: is_delivered
+        description: "1 if delivered, 0 otherwise."
+        data_tests:
+          - not_null
+
+      - name: is_canceled
+        description: "1 if canceled, 0 otherwise."
+        data_tests:
+          - not_null
+
+      - name: total_payment_value
+        description: "Total payment value for the order (BRL)."
+
+      - name: payment_installments_max
+        description: "Max installments across payments."
+
+      - name: payment_method_count
+        description: "Number of distinct payment methods."
+
+      - name: payment_type_list
+        description: "Comma-separated payment types."
+
+      - name: payment_count
+        description: "Number of payment records."
+
+      - name: review_score
+        description: "Customer review score (1-5). Null if no review."
+
+      - name: review_comment_title
+        description: "Review title. Null if no review."
+
+      - name: review_comment_message
+        description: "Review body. Null if no review."
+
+      - name: delivery_days
+        description: "Days from purchase to delivery. Null if not delivered."
+
+      - name: estimated_delivery_days
+        description: "Days from purchase to estimated delivery date."
+
+      - name: delay_days
+        description: "Days late (positive) or early (negative). Null if not delivered or dates missing."
+
+      - name: is_delayed
+        description: "1 if delayed, 0 if on-time, null if not delivered or dates missing."

--- a/dbt_project/models/intermediate/int_order_status_normalized.sql
+++ b/dbt_project/models/intermediate/int_order_status_normalized.sql
@@ -1,0 +1,40 @@
+-- int_order_status_normalized.sql
+--
+-- Maps raw order statuses to a simplified set of normalized statuses
+-- and adds boolean convenience flags.
+--
+-- Mapping:
+--   created, approved     → placed
+--   invoiced, shipped     → in_transit
+--   delivered             → delivered
+--   canceled              → canceled
+--   unavailable, other    → other
+
+with orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+normalized as (
+
+    select
+        order_id,
+        order_status as raw_status,
+
+        case
+            when order_status in ('created', 'approved')    then 'placed'
+            when order_status in ('invoiced', 'shipped')    then 'in_transit'
+            when order_status = 'delivered'                  then 'delivered'
+            when order_status = 'canceled'                   then 'canceled'
+            else 'other'
+        end                                                 as normalized_status,
+
+        (order_status = 'delivered')::int                   as is_delivered,
+        (order_status = 'canceled')::int                    as is_canceled
+
+    from orders
+
+)
+
+select * from normalized

--- a/dbt_project/models/intermediate/int_orders_enriched.sql
+++ b/dbt_project/models/intermediate/int_orders_enriched.sql
@@ -1,0 +1,114 @@
+-- int_orders_enriched.sql
+--
+-- Keystone intermediate model. Joins orders with payments, normalized
+-- status, and reviews. Computes delay metrics following definitions
+-- from docs/definitions.md.
+--
+-- Grain: 1 row per order_id (matches stg_orders).
+
+with orders as (
+
+    select * from {{ ref('stg_orders') }}
+
+),
+
+payments as (
+
+    select * from {{ ref('int_payments_aggregated') }}
+
+),
+
+status as (
+
+    select * from {{ ref('int_order_status_normalized') }}
+
+),
+
+-- Deduplicate reviews: keep the most recent review per order
+reviews as (
+
+    select * from (
+        select
+            order_id,
+            review_score,
+            review_comment_title,
+            review_comment_message,
+            review_created_at,
+            review_answered_at,
+            row_number() over (
+                partition by order_id
+                order by review_created_at desc
+            ) as rn
+        from {{ ref('stg_order_reviews') }}
+    )
+    where rn = 1
+
+),
+
+enriched as (
+
+    select
+        -- Order core
+        o.order_id,
+        o.customer_id,
+        o.order_purchased_at,
+        o.order_approved_at,
+        o.order_delivered_carrier_at,
+        o.order_delivered_customer_at,
+        o.order_estimated_delivery_at,
+
+        -- Status
+        s.raw_status                                        as order_status,
+        s.normalized_status,
+        s.is_delivered,
+        s.is_canceled,
+
+        -- Payments
+        p.total_payment_value,
+        p.payment_installments_max,
+        p.payment_method_count,
+        p.payment_type_list,
+        p.payment_count,
+
+        -- Reviews (nullable — not all orders have reviews)
+        r.review_score,
+        r.review_comment_title,
+        r.review_comment_message,
+
+        -- Delivery metrics (only for delivered orders with both dates)
+        case
+            when s.is_delivered = 1
+                 and o.order_delivered_customer_at is not null
+                 and o.order_purchased_at is not null
+            then datediff('day', o.order_purchased_at, o.order_delivered_customer_at)
+        end                                                 as delivery_days,
+
+        case
+            when o.order_estimated_delivery_at is not null
+                 and o.order_purchased_at is not null
+            then datediff('day', o.order_purchased_at, o.order_estimated_delivery_at)
+        end                                                 as estimated_delivery_days,
+
+        -- Delay metrics (per docs/definitions.md)
+        case
+            when s.is_delivered = 1
+                 and o.order_delivered_customer_at is not null
+                 and o.order_estimated_delivery_at is not null
+            then datediff('day', o.order_estimated_delivery_at, o.order_delivered_customer_at)
+        end                                                 as delay_days,
+
+        case
+            when s.is_delivered = 1
+                 and o.order_delivered_customer_at is not null
+                 and o.order_estimated_delivery_at is not null
+            then (o.order_delivered_customer_at > o.order_estimated_delivery_at)::int
+        end                                                 as is_delayed
+
+    from orders o
+    left join payments p on o.order_id = p.order_id
+    left join status s on o.order_id = s.order_id
+    left join reviews r on o.order_id = r.order_id
+
+)
+
+select * from enriched

--- a/dbt_project/models/intermediate/int_payments_aggregated.sql
+++ b/dbt_project/models/intermediate/int_payments_aggregated.sql
@@ -1,0 +1,29 @@
+-- int_payments_aggregated.sql
+--
+-- Aggregates payment-level data to one row per order.
+-- Downstream models join to this instead of stg_order_payments
+-- to avoid row duplication from multi-payment orders.
+
+with payments as (
+
+    select * from {{ ref('stg_order_payments') }}
+
+),
+
+aggregated as (
+
+    select
+        order_id,
+        sum(payment_value)                                  as total_payment_value,
+        max(payment_installments)                           as payment_installments_max,
+        count(distinct payment_type)                        as payment_method_count,
+        string_agg(distinct payment_type, ', ' order by payment_type)
+                                                            as payment_type_list,
+        count(*)                                            as payment_count
+
+    from payments
+    group by order_id
+
+)
+
+select * from aggregated


### PR DESCRIPTION
## Summary

- Resolve domain complexity: multi-payment aggregation, status normalization, and enriched orders table
- After this phase, marts models join to a single enriched table instead of managing multi-table logic

## Changes

**3 intermediate models** (`dbt_project/models/intermediate/`):
- `int_payments_aggregated` — groups payments by order_id, computes total_payment_value, payment_installments_max, payment_method_count, payment_type_list
- `int_order_status_normalized` — maps raw statuses to simplified set (placed, in_transit, delivered, canceled, other) with is_delivered/is_canceled boolean flags
- `int_orders_enriched` — keystone model joining orders + payments + status + reviews; computes delivery_days, estimated_delivery_days, delay_days, is_delayed per docs/definitions.md

**Schema tests** (`_int__models.yml`):
- PK unique/not_null on all 3 models
- accepted_values on normalized_status, is_delivered, is_canceled
- Column descriptions for all fields

## Testing

- [ ] `dbt build --select intermediate` passes with 0 failures
- [ ] int_orders_enriched row count matches stg_orders
- [ ] is_delayed = 1 only when delay_days > 0
- [ ] Payment totals match stg_order_payments aggregation
