### PR TITLE
feat(phase-4): metrics layer with GMV, revenue, and delay rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Phase 4 — Metrics Layer
+
+- Add `met_daily_gmv` — sum of `total_payment_value` by `order_date` for valid orders (`docs/definitions.md`)
+- Add `met_daily_revenue` — same field, delivered valid orders only; formula decision documented in `docs/metrics.md`
+- Add `met_daily_delay_rate` — delayed / eligible delivered per `order_date` using `safe_divide`
+- Add macros `safe_divide`, `cents_to_currency`
+- Add `_metrics__models.yml` with schema tests; singular tests for GMV/revenue totals vs `fact_orders` and delay_rate bounds
+- Extend `selectors.yml` with `metrics` selector (`+path:models/metrics`)
+
 ### Phase 2 — Intermediate (Business Rules)
 
 - Create `int_payments_aggregated` — one row per order with total payment, installments, method count

--- a/dbt_project/macros/cents_to_currency.sql
+++ b/dbt_project/macros/cents_to_currency.sql
@@ -1,0 +1,3 @@
+{% macro cents_to_currency(cents_expr) -%}
+( cast(({{ cents_expr }}) as double) / 100.0 )
+{%- endmacro %}

--- a/dbt_project/macros/safe_divide.sql
+++ b/dbt_project/macros/safe_divide.sql
@@ -1,0 +1,9 @@
+{% macro safe_divide(numerator, denominator) -%}
+(
+    case
+        when ({{ denominator }}) is null then null
+        when ({{ denominator }}) = 0 then null
+        else cast(({{ numerator }}) as double) / cast(({{ denominator }}) as double)
+    end
+)
+{%- endmacro %}

--- a/dbt_project/models/metrics/_metrics__models.yml
+++ b/dbt_project/models/metrics/_metrics__models.yml
@@ -1,0 +1,61 @@
+version: 2
+
+models:
+
+  - name: met_daily_gmv
+    description: >
+      Daily gross merchandise value (GMV). Sum of total_payment_value for valid orders
+      (see docs/definitions.md) grouped by purchase date (order_date).
+    columns:
+      - name: order_date
+        description: "Purchase calendar date; grain key."
+        data_tests:
+          - unique
+          - not_null
+
+      - name: gmv
+        description: "Sum of total_payment_value in BRL for valid orders on this date."
+        data_tests:
+          - not_null
+
+  - name: met_daily_revenue
+    description: >
+      Daily revenue: sum of total_payment_value for delivered orders with at least one
+      line item, by purchase date. Narrower than GMV (see docs/metrics.md).
+    columns:
+      - name: order_date
+        description: "Purchase calendar date; grain key."
+        data_tests:
+          - unique
+          - not_null
+
+      - name: revenue
+        description: "Sum of total_payment_value in BRL for delivered valid orders on this date."
+        data_tests:
+          - not_null
+
+  - name: met_daily_delay_rate
+    description: >
+      Daily delay rate among delivered orders eligible for delay classification
+      (both delivery and estimated dates present). Ratio uses safe_divide.
+    columns:
+      - name: order_date
+        description: "Purchase calendar date; grain key."
+        data_tests:
+          - unique
+          - not_null
+
+      - name: delay_rate
+        description: "Fraction of eligible delivered orders that were delayed (0–1)."
+        data_tests:
+          - not_null
+
+      - name: delivered_eligible_orders
+        description: "Count of delivered orders in denominator for this date."
+        data_tests:
+          - not_null
+
+      - name: delayed_orders
+        description: "Count of delayed orders (is_delayed = 1) for this date."
+        data_tests:
+          - not_null

--- a/dbt_project/models/metrics/met_daily_delay_rate.sql
+++ b/dbt_project/models/metrics/met_daily_delay_rate.sql
@@ -1,0 +1,38 @@
+-- met_daily_delay_rate.sql
+--
+-- Daily delay rate. Grain: one row per order_date with eligible delivered orders.
+-- Eligible: delivered, both delivery and estimated dates present, is_delayed defined.
+-- Formula: delayed count / eligible delivered count (safe_divide macro).
+
+with eligible as (
+
+    select
+        fo.order_date,
+        fo.is_delayed
+    from {{ ref('fact_orders') }} as fo
+    inner join {{ ref('int_orders_enriched') }} as e
+        on fo.order_id = e.order_id
+    where e.order_status = 'delivered'
+      and fo.delivery_date is not null
+      and fo.estimated_delivery_date is not null
+      and fo.is_delayed is not null
+      and fo.order_date is not null
+
+),
+
+aggregated as (
+
+    select
+        order_date,
+        {{ safe_divide(
+            'sum(case when is_delayed = 1 then 1 else 0 end)',
+            'count(*)'
+        ) }} as delay_rate,
+        count(*) as delivered_eligible_orders,
+        sum(case when is_delayed = 1 then 1 else 0 end) as delayed_orders
+    from eligible
+    group by order_date
+
+)
+
+select * from aggregated

--- a/dbt_project/models/metrics/met_daily_gmv.sql
+++ b/dbt_project/models/metrics/met_daily_gmv.sql
@@ -1,0 +1,30 @@
+-- met_daily_gmv.sql
+--
+-- Daily GMV (gross merchandise value). Grain: one row per order_date with activity.
+-- Formula: SUM(total_payment_value) for valid orders only (docs/definitions.md).
+
+with base as (
+
+    select
+        fo.order_date,
+        fo.total_payment_value
+    from {{ ref('fact_orders') }} as fo
+    inner join {{ ref('int_orders_enriched') }} as e
+        on fo.order_id = e.order_id
+    where e.order_status in ('delivered', 'shipped', 'invoiced', 'processing')
+      and fo.item_count >= 1
+      and fo.order_date is not null
+
+),
+
+aggregated as (
+
+    select
+        order_date,
+        sum(coalesce(total_payment_value, 0)) as gmv
+    from base
+    group by order_date
+
+)
+
+select * from aggregated

--- a/dbt_project/models/metrics/met_daily_revenue.sql
+++ b/dbt_project/models/metrics/met_daily_revenue.sql
@@ -1,0 +1,34 @@
+-- met_daily_revenue.sql
+--
+-- Daily revenue. Grain: one row per order_date with activity.
+--
+-- Formula decision (docs/metrics.md): same monetary field as GMV — total_payment_value
+-- from fact_orders — but restricted to orders that have completed as delivered.
+-- This matches “recognized” sales for the day of purchase; GMV includes in-flight
+-- valid orders (shipped, processing, etc.).
+
+with base as (
+
+    select
+        fo.order_date,
+        fo.total_payment_value
+    from {{ ref('fact_orders') }} as fo
+    inner join {{ ref('int_orders_enriched') }} as e
+        on fo.order_id = e.order_id
+    where e.order_status = 'delivered'
+      and fo.item_count >= 1
+      and fo.order_date is not null
+
+),
+
+aggregated as (
+
+    select
+        order_date,
+        sum(coalesce(total_payment_value, 0)) as revenue
+    from base
+    group by order_date
+
+)
+
+select * from aggregated

--- a/dbt_project/selectors.yml
+++ b/dbt_project/selectors.yml
@@ -2,3 +2,7 @@ selectors:
   - name: marts
     description: "Marts models and all upstream dependencies (staging + intermediate)."
     definition: "+path:models/marts"
+
+  - name: metrics
+    description: "Metrics models and all upstream dependencies (through fact_orders)."
+    definition: "+path:models/metrics"

--- a/dbt_project/tests/assert_met_daily_delay_rate_bounds.sql
+++ b/dbt_project/tests/assert_met_daily_delay_rate_bounds.sql
@@ -1,0 +1,5 @@
+-- delay_rate must lie in [0, 1] for all daily rows
+select *
+from {{ ref('met_daily_delay_rate') }}
+where delay_rate < 0
+   or delay_rate > 1

--- a/dbt_project/tests/assert_met_daily_gmv_matches_valid_orders.sql
+++ b/dbt_project/tests/assert_met_daily_gmv_matches_valid_orders.sql
@@ -1,0 +1,22 @@
+-- Total GMV across days must equal sum of payments for valid orders in fact_orders
+with from_metric as (
+
+    select round(coalesce(sum(gmv), 0), 6) as total from {{ ref('met_daily_gmv') }}
+
+),
+
+from_fact as (
+
+    select round(coalesce(sum(coalesce(fo.total_payment_value, 0)), 0), 6) as total
+    from {{ ref('fact_orders') }} as fo
+    inner join {{ ref('int_orders_enriched') }} as e
+        on fo.order_id = e.order_id
+    where e.order_status in ('delivered', 'shipped', 'invoiced', 'processing')
+      and fo.item_count >= 1
+
+)
+
+select m.total as metric_total, f.total as fact_total
+from from_metric m
+cross join from_fact f
+where m.total is distinct from f.total

--- a/dbt_project/tests/assert_met_daily_revenue_matches_delivered.sql
+++ b/dbt_project/tests/assert_met_daily_revenue_matches_delivered.sql
@@ -1,0 +1,22 @@
+-- Total revenue across days must equal sum of payments for delivered valid orders
+with from_metric as (
+
+    select round(coalesce(sum(revenue), 0), 6) as total from {{ ref('met_daily_revenue') }}
+
+),
+
+from_fact as (
+
+    select round(coalesce(sum(coalesce(fo.total_payment_value, 0)), 0), 6) as total
+    from {{ ref('fact_orders') }} as fo
+    inner join {{ ref('int_orders_enriched') }} as e
+        on fo.order_id = e.order_id
+    where e.order_status = 'delivered'
+      and fo.item_count >= 1
+
+)
+
+select m.total as metric_total, f.total as fact_total
+from from_metric m
+cross join from_fact f
+where m.total is distinct from f.total

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,31 +1,72 @@
 # Metric Definitions
 
-Formal definitions for all business metrics computed by the platform. Each metric is implemented as a dbt model in `dbt_project/models/metrics/`.
+Formal definitions for all business metrics computed by the platform. Each metric is implemented as a single dbt model in `dbt_project/models/metrics/`. Amounts use **`total_payment_value`** from `fact_orders` (order-level sum of payments from `int_payments_aggregated`), in **BRL**. The Olist extract is already in currency units (not integer cents); the optional macro `cents_to_currency` exists for future sources stored as cents.
+
+---
+
+## Valid order (shared filter)
+
+All metrics that reference “valid orders” apply the definition in **`docs/definitions.md`**:
+
+1. Raw `order_status` ∈ `delivered`, `shipped`, `invoiced`, `processing`
+2. At least one line item: `fact_orders.item_count >= 1`
 
 ---
 
 ## Daily GMV (Gross Merchandise Value)
 
-- **Model:** `met_daily_gmv`
-- **Definition:** Sum of `payment_value` for all valid orders per day
-- **Grain:** 1 row per day
-- **Filter:** Valid orders only (see `docs/definitions.md`)
+| | |
+|---|---|
+| **Model** | `met_daily_gmv` |
+| **Grain** | One row per **`order_date`** (purchase date) that has at least one qualifying order |
+| **Formula** | `SUM(COALESCE(total_payment_value, 0))` over valid orders |
+| **SQL filter** | Join `fact_orders` to `int_orders_enriched`; valid status list + `item_count >= 1` + `order_date IS NOT NULL` |
+
+GMV is the single top-line total for in-flight and completed valid commerce on the purchase date.
 
 ---
 
 ## Daily Revenue
 
-- **Model:** `met_daily_revenue`
-- **Definition:** Sum of `payment_value` for delivered orders per day
-- **Grain:** 1 row per day
-- **Filter:** `order_status = 'delivered'`
+| | |
+|---|---|
+| **Model** | `met_daily_revenue` |
+| **Grain** | One row per **`order_date`** with at least one qualifying order |
+| **Formula** | `SUM(COALESCE(total_payment_value, 0))` |
+| **SQL filter** | Valid-order slice **and** `order_status = 'delivered'` |
+
+**Formula decision:** Revenue uses the **same** monetary field as GMV (`total_payment_value`) so figures are comparable. The **only** change versus GMV is the status filter: **delivered only**. That matches “recognized” completed sales on the purchase date, while GMV still includes orders that are shipped or in processing. Alternative definitions (e.g. net of refunds, freight-only) would require new source fields and are out of scope here.
 
 ---
 
 ## Daily Delay Rate
 
-- **Model:** `met_daily_delay_rate`
-- **Definition:** Count of delayed orders / count of delivered orders per day
-- **Grain:** 1 row per day
-- **Filter:** Delivered orders with both delivery dates non-null
-- **Target range:** Lower is better. Baseline to be established in Phase 4.
+| | |
+|---|---|
+| **Model** | `met_daily_delay_rate` |
+| **Grain** | One row per **`order_date`** with at least one **eligible** delivered order |
+| **Eligible rows** | `order_status = 'delivered'` and `delivery_date` and `estimated_delivery_date` both non-null and `is_delayed` in (0, 1) (see `docs/definitions.md`) |
+| **Formula** | `delayed_orders / delivered_eligible_orders` using the **`safe_divide`** macro ( **`NULL`** if denominator were zero; never happens for an existing group, but keeps logic consistent) |
+| **Range** | `delay_rate` ∈ [0, 1] |
+
+Supporting columns **`delivered_eligible_orders`** and **`delayed_orders`** are exposed for auditing and tests.
+
+---
+
+## Macros
+
+| Macro | Purpose |
+|---|---|
+| `safe_divide(numerator, denominator)` | SQL expressions as strings; returns `NULL` if denominator is null or zero |
+| `cents_to_currency(expr)` | Divide by100; optional if a source stores amounts as integer cents |
+
+---
+
+## Building and testing
+
+```bash
+cd dbt_project
+dbt build --selector metrics
+```
+
+Plain `dbt build --select path:models/metrics` does **not** build upstream refs (e.g. `fact_orders`). Prefer **`--selector metrics`** or **`dbt build --select "+path:models/metrics"`**.


### PR DESCRIPTION
## Summary
Implementa a **Fase 4 — Metrics Layer**: três séries diárias (`met_daily_gmv`, `met_daily_revenue`, `met_daily_delay_rate`), macros reutilizáveis e definições formais em `docs/metrics.md`.
Closes #15
Closes #16
Closes #17
*(Remova ou ajuste os `Closes` se os números das issues forem outros.)*
## Changes
- `dbt_project/models/metrics/met_daily_gmv.sql` — GMV diário (pedidos válidos; `total_payment_value` por `order_date`).
- `dbt_project/models/metrics/met_daily_revenue.sql` — receita diária (válidos **e** `delivered`); decisão de fórmula no modelo e em `docs/metrics.md`.
- `dbt_project/models/metrics/met_daily_delay_rate.sql` — taxa de atraso com `safe_divide`; denominador = entregues elegíveis (duas datas + `is_delayed` definido).
- `dbt_project/models/metrics/_metrics__models.yml` — documentação e testes de schema.
- `dbt_project/macros/safe_divide.sql`, `cents_to_currency.sql`.
- `dbt_project/tests/assert_met_daily_gmv_matches_valid_orders.sql`, `assert_met_daily_revenue_matches_delivered.sql`, `assert_met_daily_delay_rate_bounds.sql`.
- `dbt_project/selectors.yml` — selector `metrics`.
- `docs/metrics.md` — definições alinhadas ao código.
- `CHANGELOG.md` — entrada Phase 4 em `[Unreleased]`.
## Testing
- [x] `dbt build --selector metrics` *(ou `dbt build --select "+path:models/metrics"`)*  
- [x] Testes de schema e singulares dos metrics passando  
- [x] Spot-check manual opcional nas tabelas `met_*` no DuckDB  
## Checklist
- [x] Convenções do projeto  
- [x] Documentação atualizada (`docs/metrics.md`, YAML, CHANGELOG)  
- [x] Sem vazamento temporal em feature models *(N/A — sem alteração em features)*  
- [x] CHANGELOG atualizado *(para release com tag, se for o caso)*  
