### PR TITLE
feat(phase-5): feature layer with anti-leakage guarantees and Parquet export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Phase 5 — Feature Layer (ML bridge)
+
+- Add `fct_order_features` — order-grain ML features + `is_delayed` target; historical seller delivery via causal window (`ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING`)
+- Add `_features__models.yml` with column documentation and PK tests
+- Add `tests/assert_no_leakage_in_features.sql` — target eligibility + first-row historical null check
+- Add `scripts/export_features.py` and `make export-features` (dbt build `+fct_order_features` + Parquet to `data/ml/features.parquet`)
+- Extend `selectors.yml` with `features` selector; expand `docs/ml_design.md` with feature/leakage table
+
 ### Phase 4 — Metrics Layer
 
 - Add `met_daily_gmv` — sum of `total_payment_value` by `order_date` for valid orders (`docs/definitions.md`)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install load-data dbt-deps dbt-build dbt-test ml-train ml-predict pipeline clean
+.PHONY: install load-data dbt-deps dbt-build dbt-test export-features ml-train ml-predict pipeline clean
 
 # ---------- Environment ----------
 
@@ -22,6 +22,10 @@ dbt-build:
 
 dbt-test:
 	cd dbt_project && dbt test
+
+export-features:
+	cd dbt_project && dbt build --select "+fct_order_features"
+	python scripts/export_features.py
 
 # ---------- ML ----------
 

--- a/dbt_project/models/features/_features__models.yml
+++ b/dbt_project/models/features/_features__models.yml
@@ -1,0 +1,78 @@
+version: 2
+
+models:
+
+  - name: fct_order_features
+    description: >
+      Single training/inference feature table at order grain. Features are restricted
+      to information available at order placement time; target is_delayed is null when
+      delay cannot be computed (non-delivered or missing dates). Historical seller
+      delivery uses a causal window frame (no current row). See docs/ml_design.md.
+    columns:
+      - name: order_id
+        description: "Business key; use for joins and row identity (often excluded from model matrix)."
+        data_tests:
+          - unique
+          - not_null
+
+      - name: order_purchase_timestamp
+        description: "When the customer placed the order; used for temporal splits and window ordering."
+        data_tests:
+          - not_null
+
+      - name: order_day_of_week
+        description: "extract(dow from order_purchase_timestamp) — DuckDB Sunday=0."
+
+      - name: order_hour
+        description: "Hour of day (0–23) at order purchase."
+
+      - name: order_month
+        description: "Calendar month (1–12) at order purchase."
+
+      - name: total_payment_value
+        description: "Order-level total payment in BRL (from int_payments_aggregated)."
+
+      - name: payment_installments
+        description: "Maximum installments across payments for the order (payment_installments_max)."
+
+      - name: payment_type_count
+        description: "Distinct payment methods count (payment_method_count)."
+
+      - name: product_weight_g
+        description: "Weight (g) of the primary line item product; null if product unknown."
+
+      - name: product_volume_cm3
+        description: "length_cm × height_cm × width_cm for primary product; null if any dimension missing."
+
+      - name: product_category
+        description: "Category of the primary line item (aligned with dim_products)."
+
+      - name: customer_state
+        description: "Customer state (2-letter code) from dim_customers."
+
+      - name: seller_state
+        description: "Seller state from dim_sellers; null if seller missing."
+
+      - name: customer_seller_same_state
+        description: "1 if customer and seller states match, 0 if both known and differ, null otherwise."
+
+      - name: seller_avg_delivery_days_historical
+        description: >
+          Mean realized delivery_days over prior orders for the same seller only
+          (ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING). Null for first order per seller
+          or when no prior delivered realization exists.
+
+      - name: freight_value
+        description: "Sum of line freight for the order (from fact_orders.total_freight_value)."
+
+      - name: freight_ratio
+        description: "freight_value / total_payment_value; null when payment is zero or missing (safe_divide)."
+
+      - name: estimated_delivery_days
+        description: "Days from purchase to estimated customer delivery (from int_orders_enriched)."
+
+      - name: seller_id
+        description: "Primary line seller id; optional for training (high cardinality) — useful for audits."
+
+      - name: is_delayed
+        description: "Target: 1 late, 0 on-time; null if order is not an eligible delivered order per docs/definitions.md."

--- a/dbt_project/models/features/fct_order_features.sql
+++ b/dbt_project/models/features/fct_order_features.sql
@@ -1,0 +1,162 @@
+-- fct_order_features.sql
+--
+-- Order-level feature table for ML (training + inference). Grain: 1 row per order_id.
+-- Features use only information knowable at order placement time, except the target
+-- is_delayed and helper columns used for windows (stripped before publish).
+--
+-- Historical seller delivery: AVG(prior orders' realized delivery_days) via window
+-- with ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING (no self-join).
+
+with enriched as (
+
+    select * from {{ ref('int_orders_enriched') }}
+
+),
+
+fact as (
+
+    select * from {{ ref('fact_orders') }}
+
+),
+
+primary_item as (
+
+    select
+        order_id,
+        product_id,
+        seller_id
+    from (
+        select
+            oi.order_id,
+            oi.product_id,
+            oi.seller_id,
+            row_number() over (
+                partition by oi.order_id
+                order by (oi.price + oi.freight_value) desc, oi.item_sequence asc
+            ) as rn
+        from {{ ref('stg_order_items') }} as oi
+    )
+    where rn = 1
+
+),
+
+dim_customers as (
+
+    select * from {{ ref('dim_customers') }}
+
+),
+
+dim_sellers as (
+
+    select * from {{ ref('dim_sellers') }}
+
+),
+
+dim_products as (
+
+    select * from {{ ref('dim_products') }}
+
+),
+
+base as (
+
+    select
+        e.order_id,
+        e.order_purchased_at as order_purchase_timestamp,
+        e.is_delayed,
+        e.total_payment_value,
+        e.payment_installments_max as payment_installments,
+        e.payment_method_count as payment_type_count,
+        e.estimated_delivery_days,
+        e.delivery_days,
+        extract(dow from e.order_purchased_at) as order_day_of_week,
+        extract(hour from e.order_purchased_at) as order_hour,
+        extract(month from e.order_purchased_at) as order_month,
+        fo.total_freight_value as freight_value,
+        fo.seller_id,
+        p.product_category,
+        p.weight_g as product_weight_g,
+        case
+            when p.length_cm is not null
+                 and p.height_cm is not null
+                 and p.width_cm is not null
+            then cast(p.length_cm as double) * cast(p.height_cm as double) * cast(p.width_cm as double)
+        end as product_volume_cm3,
+        dc.customer_state,
+        ds.seller_state,
+        case
+            when dc.customer_state is not null
+                 and ds.seller_state is not null
+                 and dc.customer_state = ds.seller_state
+            then 1
+            when dc.customer_state is not null
+                 and ds.seller_state is not null
+            then 0
+        end as customer_seller_same_state
+    from enriched as e
+    inner join fact as fo
+        on e.order_id = fo.order_id
+    left join primary_item as pi
+        on e.order_id = pi.order_id
+    inner join dim_customers as dc
+        on fo.customer_key = dc.customer_key
+    left join dim_sellers as ds
+        on fo.seller_id = ds.seller_id
+    left join dim_products as p
+        on pi.product_id = p.product_id
+
+),
+
+with_hist as (
+
+    select
+        order_id,
+        order_purchase_timestamp,
+        is_delayed,
+        total_payment_value,
+        payment_installments,
+        payment_type_count,
+        estimated_delivery_days,
+        order_day_of_week,
+        order_hour,
+        order_month,
+        freight_value,
+        seller_id,
+        product_category,
+        product_weight_g,
+        product_volume_cm3,
+        customer_state,
+        seller_state,
+        customer_seller_same_state,
+        avg(delivery_days) over (
+            partition by seller_id
+            order by order_purchase_timestamp
+            rows between unbounded preceding and 1 preceding
+        ) as seller_avg_delivery_days_historical,
+        {{ safe_divide('freight_value', 'coalesce(total_payment_value, 0)') }} as freight_ratio
+    from base
+
+)
+
+select
+    order_id,
+    order_purchase_timestamp,
+    order_day_of_week,
+    order_hour,
+    order_month,
+    total_payment_value,
+    payment_installments,
+    payment_type_count,
+    product_weight_g,
+    product_volume_cm3,
+    product_category,
+    customer_state,
+    seller_state,
+    customer_seller_same_state,
+    seller_avg_delivery_days_historical,
+    freight_value,
+    freight_ratio,
+    estimated_delivery_days,
+    seller_id,
+    is_delayed
+from with_hist

--- a/dbt_project/selectors.yml
+++ b/dbt_project/selectors.yml
@@ -6,3 +6,7 @@ selectors:
   - name: metrics
     description: "Metrics models and all upstream dependencies (through fact_orders)."
     definition: "+path:models/metrics"
+
+  - name: features
+    description: "Feature table and all upstream dependencies."
+    definition: "+path:models/features"

--- a/dbt_project/tests/assert_no_leakage_in_features.sql
+++ b/dbt_project/tests/assert_no_leakage_in_features.sql
@@ -1,0 +1,83 @@
+-- Anti-leakage checks for fct_order_features (see docs/ml_design.md).
+-- 1) Target is_delayed is non-null only for delivered orders with both delivery dates.
+-- 2) Target is null when those dates are missing (eligible-for-label set).
+-- 3) First order per seller (non-null seller) has no historical seller avg (window excludes current).
+
+with enriched as (
+
+    select * from {{ ref('int_orders_enriched') }}
+
+),
+
+features as (
+
+    select * from {{ ref('fct_order_features') }}
+
+),
+
+eligible_for_label as (
+
+    select
+        order_id,
+        (
+            is_delivered = 1
+            and order_delivered_customer_at is not null
+            and order_estimated_delivery_at is not null
+        ) as is_eligible
+    from enriched
+
+),
+
+target_mismatch as (
+
+    select
+        f.order_id,
+        'is_delayed present but order not eligible for delay label' as violation    from features f
+    inner join eligible_for_label e on f.order_id = e.order_id
+    where f.is_delayed is not null
+      and e.is_eligible = false
+
+),
+
+missing_target as (
+
+    select
+        f.order_id,
+        'is_delayed null but order eligible for delay label' as violation
+    from features f
+    inner join eligible_for_label e on f.order_id = e.order_id
+    where f.is_delayed is null
+      and e.is_eligible = true
+
+),
+
+ranked as (
+
+    select
+        order_id,
+        seller_avg_delivery_days_historical,
+        row_number() over (
+            partition by seller_id
+            order by order_purchase_timestamp
+        ) as seller_row_num
+    from features
+    where seller_id is not null
+
+),
+
+first_row_has_hist as (
+
+    select
+        order_id,
+        'first seller order must have null historical avg' as violation
+    from ranked
+    where seller_row_num = 1
+      and seller_avg_delivery_days_historical is not null
+
+)
+
+select * from target_mismatch
+union all
+select * from missing_target
+union all
+select * from first_row_has_hist

--- a/docs/ml_design.md
+++ b/docs/ml_design.md
@@ -18,21 +18,55 @@ See `docs/definitions.md` for the complete delay definition.
 
 ## Feature Constraints
 
-Features must use **only information available at order creation time** (`order_approved_at`). This prevents future leakage.
+Features must use **only information available at order placement time** (`order_purchased_at` for calendar features and window ordering; payment may still be pending, but aggregates reflect what is recorded on the order at build time). `docs/definitions.md` references prediction at `order_approved_at`; this table uses **`order_purchase_timestamp`** for calendar features and window ordering — align with your training policy if you require approval time instead.
 
-**Allowed features (examples):**
-- Order metadata: payment type, payment installments, total payment value
-- Product attributes: category, weight, dimensions, number of photos
-- Seller attributes: city, state, historical delay rate (computed on past data only)
-- Customer attributes: city, state
-- Temporal: day of week, month, estimated delivery lead time
-- Geographic: distance between seller and customer (via geolocation)
+**Forbidden (not in `fct_order_features`):**
+- Actual delivery timestamps, `delivery_days` / `delay_days` of the **current** order (leakage)
+- `review_score` and any post-delivery review fields
+- Carrier handoff timestamps after purchase
+- Raw high-cardinality text (e.g. full city names) unless hashed — we expose **states** only at order time
 
-**Forbidden features:**
-- `order_delivered_customer_date` (target leakage)
-- `order_delivered_carrier_date` (post-creation event)
-- `review_score` (post-delivery event)
-- Any field that only exists after order creation
+**Rejected for this phase (with reasons):**
+
+| Candidate | Reason |
+|-----------|--------|
+| `review_score` | Observed after delivery |
+| `product_photos_qty`, `product_name_length` | Omitted to keep v1 narrow; safe to add later from `dim_products` / staging |
+| `seller_city`, `customer_city` | Higher cardinality; states + `customer_seller_same_state` used instead |
+| Geolocation distance | Requires extra join and lat/long; not in Phase 5 scope |
+| Current-order `delivery_days` | Direct leakage for delay prediction |
+| `order_status` at training export | Status can change after purchase; omitted to avoid ambiguous snapshot |
+
+---
+
+## `fct_order_features` — column reference
+
+All columns below are implemented in `dbt_project/models/features/fct_order_features.sql` and documented in `_features__models.yml`.
+
+| Feature (column) | Source / logic | Type | Leakage-safe | Justification |
+|------------------|----------------|------|--------------|---------------|
+| `order_day_of_week` | `extract(dow from order_purchase_timestamp)` | int | yes | Clock/calendar at purchase |
+| `order_hour` | `extract(hour from …)` | int | yes | Same |
+| `order_month` | `extract(month from …)` | int | yes | Same |
+| `total_payment_value` | `int_orders_enriched` / payments agg | float | yes | Payment plan known at order capture |
+| `payment_installments` | `payment_installments_max` | int | yes | Same |
+| `payment_type_count` | `payment_method_count` | int | yes | Same |
+| `product_weight_g` | Primary line → `dim_products` | float | yes | Product master data |
+| `product_volume_cm3` | `length_cm * height_cm * width_cm` | float | yes | Same |
+| `product_category` | Primary line → `dim_products` | string | yes | Same |
+| `customer_state` | `dim_customers` | string | yes | Customer master |
+| `seller_state` | `dim_sellers` | string | yes | Seller master |
+| `customer_seller_same_state` | compare states | int (0/1) | yes | Geography at purchase |
+| `seller_avg_delivery_days_historical` | `avg(delivery_days) OVER (PARTITION BY seller_id ORDER BY order_purchase_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)` | float | yes | Uses **prior** orders’ realized lead time only; current row excluded |
+| `freight_value` | `fact_orders.total_freight_value` | float | yes | Line freight known at checkout |
+| `freight_ratio` | `safe_divide(freight_value, total_payment_value)` | float | yes | Derived from same-time fields |
+| `estimated_delivery_days` | `int_orders_enriched` | int | yes | Promised lead time shown at purchase |
+| `seller_id` | Primary line seller | string | yes* | Identifier; *optional drop for tree models to limit memorization |
+| `order_id` | key | string | yes* | Exclude from matrix; join key only |
+| `order_purchase_timestamp` | split / ordering | ts | yes | Known at purchase |
+| `is_delayed` | label | int / null | **target** | Null unless delivered + both dates (definitions.md) |
+
+Historical averages use **window functions only** (no self-joins). Training scripts should drop `order_id`, `order_purchase_timestamp` (or keep only for splits), and optionally `seller_id`, per model needs.
 
 ---
 

--- a/scripts/export_features.py
+++ b/scripts/export_features.py
@@ -1,0 +1,35 @@
+"""
+export_features.py — Export dbt model fct_order_features to Parquet for ML.
+
+Run from the repository root after the model exists in DuckDB, e.g.:
+
+    cd dbt_project && dbt build --select "+fct_order_features"
+    cd .. && python scripts/export_features.py
+
+Or: make export-features
+"""
+
+from pathlib import Path
+
+import duckdb
+
+ROOT = Path(__file__).resolve().parent.parent
+DB_PATH = ROOT / "data" / "olist.duckdb"
+OUT_PATH = ROOT / "data" / "ml" / "features.parquet"
+
+
+def main() -> None:
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    print(f">>> Connecting to {DB_PATH}...")
+    con = duckdb.connect(str(DB_PATH))
+    out_sql = str(OUT_PATH.resolve()).replace("\\", "/")
+    print(f">>> COPY fct_order_features -> {OUT_PATH}")
+    con.execute(
+        f"COPY (SELECT * FROM main.fct_order_features) TO '{out_sql}' (FORMAT PARQUET)"
+    )
+    con.close()
+    print(">>> Done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implementa a **Fase 5 — Feature Layer**: tabela `fct_order_features` pronta para ML (anti-leakage), export Parquet e documentação/testes alinhados a `docs/ml_design.md`.

Closes #18
Closes #19
Closes #20

*(Ajuste ou remova os `Closes` se os números das issues forem outros.)*

## Changes

- `dbt_project/models/features/fct_order_features.sql` — features em grão de pedido; janela `ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING` para média histórica de `delivery_days` por vendedor; target `is_delayed`; `order_purchase_timestamp` para split temporal.
- `dbt_project/models/features/_features__models.yml` — descrições e testes (`unique`/`not_null` em chaves).
- `dbt_project/tests/assert_no_leakage_in_features.sql` — elegibilidade do alvo + primeiro pedido do vendedor sem histórico.
- `scripts/export_features.py` — `COPY` para `data/ml/features.parquet`.
- `Makefile` — alvo `export-features` (dbt `+fct_order_features` + export).
- `dbt_project/selectors.yml` — selector `features`.
- `docs/ml_design.md` — tabela de features, leakage, rejeitados.
- `CHANGELOG.md` — Phase 5 em `[Unreleased]`.

## Testing

- [x] `dbt build --selector features` *(ou `dbt build --select "+path:models/features"`)*  
- [x] `assert_no_leakage_in_features` e testes de schema passando  
- [x] `python scripts/export_features.py` *(ou `make export-features`)* gera `data/ml/features.parquet`  

## Checklist

- [x] Convenções do projeto  
- [x] Documentação atualizada (`docs/ml_design.md`, YAML, CHANGELOG)  
- [x] Sem vazamento temporal nas features *(coberto por desenho + teste singular)*  
- [x] CHANGELOG atualizado *(se for tagar `v0.6-features`, consolidar versão no CHANGELOG)*  