### PR TITLE
feat(phase-7): batch inference pipeline with model registry integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Phase 7 — Inference Pipeline
+
+- Add `ml/predict.py` — read `current_model.yaml`, score `features.parquet`, write `ml/predictions/predictions_{version}_{date}.parquet` and DuckDB `main.ml_predictions`
+- Add `ml/feature_config.py` — shared feature column list for train/predict
+- Add dbt source `ml_pipeline.ml_predictions` (`_ml__sources.yml`) and bridge model `fct_predictions`
+- Add tests: rowcount vs features Parquet, probabilities in [0, 1]; schema tests on `fct_predictions`
+- Extend `selectors.yml` (`fct_predictions`), `docs/runbook.md` (commands + SQL example), `pyproject.toml` (`pyyaml`)
+
 ### Phase 6 — Model Training
 
 - Add `ml/train.py` — load `data/ml/features.parquet`, temporal split (train / val / test), `ColumnTransformer` (median+`StandardScaler`, categorical `"missing"`+one-hot), `LogisticRegression` pipeline

--- a/dbt_project/models/features/_fct_predictions.yml
+++ b/dbt_project/models/features/_fct_predictions.yml
@@ -1,0 +1,45 @@
+version: 2
+
+models:
+
+  - name: fct_predictions
+    description: >
+      Order-level predictions from the active model (ml/current_model.yaml),
+      joined to fact_orders for customer key, order date, and realized is_delayed.
+    columns:
+      - name: order_id
+        description: "Order identifier; matches fact_orders."
+        data_tests:
+          - unique
+          - not_null
+
+      - name: predicted_probability
+        description: "Scoring output P(delayed); in [0, 1]."
+        data_tests:
+          - not_null
+
+      - name: predicted_class
+        description: "0/1 from 0.5 threshold on predicted_probability."
+        data_tests:
+          - not_null
+          - accepted_values:
+              values: [0, 1]
+
+      - name: model_version
+        description: "Model registry version at inference time."
+        data_tests:
+          - not_null
+
+      - name: prediction_timestamp
+        description: "When the batch job wrote this row (UTC)."
+        data_tests:
+          - not_null
+
+      - name: customer_key
+        description: "From fact_orders when the order exists there."
+
+      - name: order_date
+        description: "Purchase date from fact_orders."
+
+      - name: actual_is_delayed
+        description: "Realized label from fact_orders when defined; null otherwise."

--- a/dbt_project/models/features/fct_predictions.sql
+++ b/dbt_project/models/features/fct_predictions.sql
@@ -1,0 +1,35 @@
+-- fct_predictions.sql
+--
+-- Bridge: batch ML predictions joined to the order fact for analysis.
+-- Requires main.ml_predictions (python ml/predict.py).
+
+with predictions as (
+
+    select * from {{ source('ml_pipeline', 'ml_predictions') }}
+
+),
+
+orders as (
+
+    select * from {{ ref('fact_orders') }}
+
+),
+
+final as (
+
+    select
+        p.order_id,
+        p.predicted_probability,
+        p.predicted_class,
+        p.model_version,
+        p.prediction_timestamp,
+        o.customer_key,
+        o.order_date,
+        o.is_delayed as actual_is_delayed
+    from predictions p
+    left join orders o
+        on p.order_id = o.order_id
+
+)
+
+select * from final

--- a/dbt_project/models/sources/_ml__sources.yml
+++ b/dbt_project/models/sources/_ml__sources.yml
@@ -1,0 +1,22 @@
+version: 2
+
+sources:
+  - name: ml_pipeline
+    description: >
+      Tables written by Python ML scripts. Populated by `python ml/predict.py`
+      (batch inference). Must exist before building `fct_predictions`.
+    schema: main
+    tables:
+      - name: ml_predictions
+        description: "One row per order_id with batch model outputs and metadata."
+        columns:
+          - name: order_id
+            description: "Join key to fact_orders / fct_order_features."
+          - name: predicted_probability
+            description: "P(is_delayed = 1) from the active model."
+          - name: predicted_class
+            description: "Threshold 0.5 on predicted_probability (0 or 1)."
+          - name: model_version
+            description: "Registry version string from ml/current_model.yaml."
+          - name: prediction_timestamp
+            description: "UTC time when the batch prediction was produced."

--- a/dbt_project/selectors.yml
+++ b/dbt_project/selectors.yml
@@ -10,3 +10,7 @@ selectors:
   - name: features
     description: "Feature table and all upstream dependencies."
     definition: "+path:models/features"
+
+  - name: fct_predictions
+    description: "Prediction bridge model; requires ml_predictions table (run ml/predict.py first)."
+    definition: "+fct_predictions"

--- a/dbt_project/tests/assert_ml_predictions_rowcount_equals_features_parquet.sql
+++ b/dbt_project/tests/assert_ml_predictions_rowcount_equals_features_parquet.sql
@@ -1,0 +1,13 @@
+-- Row count in ml_predictions must match features export (same scoring universe).
+WITH feat AS (
+    SELECT COUNT(*)::BIGINT AS n
+    FROM read_parquet('../data/ml/features.parquet')
+),
+pred AS (
+    SELECT COUNT(*)::BIGINT AS n
+    FROM {{ source('ml_pipeline', 'ml_predictions') }}
+)
+SELECT feat.n AS features_rows, pred.n AS predictions_rows
+FROM feat
+CROSS JOIN pred
+WHERE feat.n != pred.n

--- a/dbt_project/tests/assert_prediction_probabilities_in_unit_interval.sql
+++ b/dbt_project/tests/assert_prediction_probabilities_in_unit_interval.sql
@@ -1,0 +1,6 @@
+-- P(delay) must lie in [0, 1].
+SELECT *
+FROM {{ source('ml_pipeline', 'ml_predictions') }}
+WHERE predicted_probability < 0
+   OR predicted_probability > 1
+   OR predicted_probability IS NULL

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -35,6 +35,36 @@ make ml-train       # Train the ML model
 make ml-predict     # Run batch predictions
 ```
 
+Without `make` (from repository root, after activating the venv):
+
+```bash
+cd dbt_project && dbt build
+cd ..
+python scripts/export_features.py
+python ml/train.py
+python ml/predict.py
+cd dbt_project && dbt build --select "+fct_predictions"
+```
+
+**Inference (Phase 7):** `python ml/predict.py` reads `ml/current_model.yaml`, loads the joblib pipeline, scores `data/ml/features.parquet`, writes `ml/predictions/predictions_{version}_{date}.parquet` and replaces DuckDB table `main.ml_predictions`. Then build `fct_predictions` so predictions join `fact_orders` in dbt.
+
+### Example: actuals vs predictions (DuckDB / dbt)
+
+After `predict.py` and `dbt build --select fct_predictions`:
+
+```sql
+SELECT fp.order_date,
+    fp.actual_is_delayed,
+    fp.predicted_class,
+    fp.predicted_probability,
+    fp.model_version
+FROM fct_predictions fp
+WHERE fp.actual_is_delayed IS NOT NULL
+LIMIT 20;
+```
+
+Use this for calibration, error analysis, and monitoring delayed vs predicted-delayed rates by date.
+
 ## Verifying the Setup
 
 ```bash

--- a/ml/feature_config.py
+++ b/ml/feature_config.py
@@ -1,0 +1,42 @@
+"""
+Shared feature matrix definition for train / predict (keep in sync with fct_order_features).
+"""
+
+from __future__ import annotations
+
+TARGET = "is_delayed"
+DROP_FROM_X = ["order_id", "order_purchase_timestamp", "seller_id"]
+
+NUMERIC_FEATURES = [
+    "order_day_of_week",
+    "order_hour",
+    "order_month",
+    "total_payment_value",
+    "payment_installments",
+    "payment_type_count",
+    "product_weight_g",
+    "product_volume_cm3",
+    "customer_seller_same_state",
+    "seller_avg_delivery_days_historical",
+    "freight_value",
+    "freight_ratio",
+    "estimated_delivery_days",
+]
+CATEGORICAL_FEATURES = [
+    "product_category",
+    "customer_state",
+    "seller_state",
+]
+
+
+def feature_columns(df_columns: list[str]) -> list[str]:
+    """Columns passed to the sklearn pipeline (excludes keys, timestamp, seller_id, target)."""
+    return [c for c in df_columns if c not in DROP_FROM_X and c != TARGET]
+
+
+def validate_expected_columns(df_columns: list[str]) -> None:
+    missing = [
+        c for c in NUMERIC_FEATURES + CATEGORICAL_FEATURES if c not in df_columns
+    ]
+    if missing:
+        raise ValueError(f"Features parquet missing expected columns: {missing}")

--- a/ml/predict.py
+++ b/ml/predict.py
@@ -1,0 +1,110 @@
+"""
+Batch inference: load active model from ml/current_model.yaml, score features Parquet,
+write versioned Parquet + DuckDB table main.ml_predictions.
+
+Usage (from repo root):
+    python ml/predict.py
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import duckdb
+import joblib
+import numpy as np
+import pandas as pd
+import yaml
+
+from feature_config import (
+    CATEGORICAL_FEATURES,
+    NUMERIC_FEATURES,
+    feature_columns,
+    validate_expected_columns,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_PATH = ROOT / "ml" / "current_model.yaml"
+DB_PATH = ROOT / "data" / "olist.duckdb"
+PREDICTIONS_DIR = ROOT / "ml" / "predictions"
+
+
+def _load_registry() -> dict:
+    if not REGISTRY_PATH.is_file():
+        raise FileNotFoundError(
+            f"Missing {REGISTRY_PATH}. Train a model first (python ml/train.py)."
+        )
+    with open(REGISTRY_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not data or "active_model" not in data:
+        raise ValueError(f"Invalid registry YAML: {REGISTRY_PATH}")
+    return data["active_model"]
+
+
+def main() -> None:
+    active = _load_registry()
+    model_rel = Path(active["path"])
+    model_path = ROOT / model_rel
+    if not model_path.is_file():
+        raise FileNotFoundError(f"Model artifact not found: {model_path}")
+
+    features_rel = Path(active["features_parquet"])
+    features_path = ROOT / features_rel
+    if not features_path.is_file():
+        raise FileNotFoundError(
+            f"Features parquet not found: {features_path}. Run export_features first."
+        )
+
+    version = str(active["version"])
+
+    pipeline = joblib.load(model_path)
+    df = pd.read_parquet(features_path)
+    if "order_id" not in df.columns:
+        raise ValueError("features parquet must include order_id")
+
+    validate_expected_columns(list(df.columns))
+    cols = feature_columns(list(df.columns))
+    num_cols = [c for c in NUMERIC_FEATURES if c in cols]
+    cat_cols = [c for c in CATEGORICAL_FEATURES if c in cols]
+
+    for c in num_cols:
+        df[c] = pd.to_numeric(df[c], errors="coerce").astype("float64")
+    for c in cat_cols:
+        df[c] = df[c].fillna("missing").astype(str)
+
+    X = df[cols]
+    proba = pipeline.predict_proba(X)[:, 1]
+    pred_class = (proba >= 0.5).astype(np.int64)
+
+    ts = datetime.now(timezone.utc)
+    out = pd.DataFrame(
+        {
+            "order_id": df["order_id"].astype(str),
+            "predicted_probability": proba.astype(float),
+            "predicted_class": pred_class,
+            "model_version": version,
+            "prediction_timestamp": ts,
+        }
+    )
+
+    if len(out) != len(df):
+        raise RuntimeError("Internal error: prediction row count mismatch.")
+
+    PREDICTIONS_DIR.mkdir(parents=True, exist_ok=True)
+    day = date.today().isoformat()
+    safe_ver = version.replace("/", "_").replace("\\", "_")
+    parquet_out = PREDICTIONS_DIR / f"predictions_{safe_ver}_{day}.parquet"
+    out.to_parquet(parquet_out, index=False)
+    print(f"Wrote predictions parquet: {parquet_out}")
+
+    print(f"Writing DuckDB table main.ml_predictions ({len(out)} rows)…")
+    con = duckdb.connect(str(DB_PATH))
+    con.register("pred_out", out)
+    con.execute("CREATE OR REPLACE TABLE ml_predictions AS SELECT * FROM pred_out")
+    con.close()
+    print("Done. Run dbt build --select +fct_predictions to refresh the bridge model.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/reports/evaluation_v1.md
+++ b/ml/reports/evaluation_v1.md
@@ -1,6 +1,6 @@
 # Evaluation report — v1 Logistic Regression
 
-Generated: `2026-04-13T00:24:02.783084+00:00` (UTC)
+Generated: `2026-04-13T00:32:24.932380+00:00` (UTC)
 
 ## Model
 

--- a/ml/train.py
+++ b/ml/train.py
@@ -30,6 +30,14 @@ from sklearn.metrics import (
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
+from feature_config import (
+    CATEGORICAL_FEATURES,
+    NUMERIC_FEATURES,
+    TARGET,
+    feature_columns,
+    validate_expected_columns,
+)
+
 ROOT = Path(__file__).resolve().parent.parent
 FEATURES_PATH = ROOT / "data" / "ml" / "features.parquet"
 MODEL_DIR = ROOT / "ml" / "models"
@@ -43,30 +51,6 @@ EVAL_REPORT_PATH = REPORT_DIR / "evaluation_v1.md"
 # Temporal boundaries (purchase timestamp, naive local time as in source)
 TRAIN_END = pd.Timestamp("2018-04-01")
 VAL_END = pd.Timestamp("2018-07-01")
-
-TARGET = "is_delayed"
-DROP_FROM_X = ["order_id", "order_purchase_timestamp", "seller_id"]
-
-NUMERIC_FEATURES = [
-    "order_day_of_week",
-    "order_hour",
-    "order_month",
-    "total_payment_value",
-    "payment_installments",
-    "payment_type_count",
-    "product_weight_g",
-    "product_volume_cm3",
-    "customer_seller_same_state",
-    "seller_avg_delivery_days_historical",
-    "freight_value",
-    "freight_ratio",
-    "estimated_delivery_days",
-]
-CATEGORICAL_FEATURES = [
-    "product_category",
-    "customer_state",
-    "seller_state",
-]
 
 
 @dataclass
@@ -323,10 +307,8 @@ def main() -> None:
     _print_class_balance(df.loc[val_mask, TARGET], "Validation")
     _print_class_balance(df.loc[test_mask, TARGET], "Test")
 
-    feature_cols = [c for c in df.columns if c not in DROP_FROM_X and c != TARGET]
-    for col in NUMERIC_FEATURES + CATEGORICAL_FEATURES:
-        if col not in df.columns:
-            raise ValueError(f"Expected column `{col}` in features parquet.")
+    validate_expected_columns(list(df.columns))
+    feature_cols = feature_columns(list(df.columns))
 
     num_cols = [c for c in NUMERIC_FEATURES if c in feature_cols]
     cat_cols = [c for c in CATEGORICAL_FEATURES if c in feature_cols]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "scikit-learn>=1.4,<2.0",
     "pandas>=2.2,<3.0",
     "pyarrow>=15.0,<20.0",
+    "pyyaml>=6.0,<7.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Implementa a **Fase 7 — Inference Pipeline**: inferência em lote guiada por `ml/current_model.yaml`, persistência em Parquet + DuckDB, ponte dbt `fct_predictions` e testes de consistência.

Closes #23
Closes #24

*(Ajuste ou remova os `Closes` se os números das issues forem outros.)*

## Changes

- `ml/predict.py` — registry YAML, joblib, `features.parquet`, `predicted_probability` / `predicted_class` (0.5), `model_version`, `prediction_timestamp`; Parquet `ml/predictions/predictions_{version}_{date}.parquet`; `CREATE OR REPLACE TABLE ml_predictions`.
- `ml/feature_config.py` — colunas compartilhadas train/predict; `train.py` refatorado para importar.
- `dbt_project/models/sources/_ml__sources.yml` — fonte `ml_pipeline.ml_predictions`.
- `dbt_project/models/features/fct_predictions.sql` + `_fct_predictions.yml` — join com `fact_orders`.
- Testes singulares: contagem vs `read_parquet(features)`; probabilidades em [0, 1].
- `selectors.yml` — selector `fct_predictions`; `docs/runbook.md`; `pyproject.toml` (`pyyaml`); `CHANGELOG.md`.

## Pré-requisito para CI / reviewers

Rodar `python ml/predict.py` antes de `dbt build --selector fct_predictions` (tabela `ml_predictions`).

## Testing

- [x] `python ml/predict.py` após export de features + treino  
- [x] `dbt build --selector fct_predictions`  
- [x] Testes de `fct_predictions` e singulares passando  

## Checklist

- [x] Convenções do projeto  
- [x] Documentação (`runbook`, CHANGELOG)  
- [x] CHANGELOG pronto para tag `v0.8-inference` *(seção versionada ao tagar, se for política do repo)*  