### PR TITLE
feat(phase-9): retraining pipeline with CI validation and full documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,19 @@ jobs:
 
       - name: Verify dbt connection
         run: cd dbt_project && dbt debug
+
+      - name: ML validation
+        run: |
+          python -m py_compile ml/train.py ml/predict.py ml/monitor.py ml/retrain.py ml/evaluate.py
+          python - <<'PY'
+          from pathlib import Path
+          import joblib
+          p = Path("ml/models/model_v1_logreg.joblib")
+          if p.is_file():
+              joblib.load(p)
+              print("Model loads OK")
+          else:
+              print("Model artifact absent (typically gitignored); skipping load check")
+          PY
+          python ml/predict.py --dry-run --skip-if-missing
+          python ml/evaluate.py --check-minimum-auc 0.55 --skip-if-missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Phase 9 — Retraining (continuous cycle)
+
+- Add `ml/retrain.py` — trigger evaluation (performance / PSI drift / calendar), extended-window refit, `model_v{N}_logreg.joblib` + `train_v{N}.parquet`, comparison report, conditional promotion in `ml/current_model.yaml`
+- Add `ml/evaluate.py` — test-slice ROC-AUC from registry; `--check-minimum-auc` for CI
+- Extend `ml/predict.py` with `--dry-run` and `--skip-if-missing`
+- Persist full **`drift`** object in `monitoring_*.json`; drift baseline path from `train_snapshot` in registry (fallback `train_v1.parquet`)
+- Add `retrain` section to `ml/config.yaml`; `train_snapshot` in registry / `train.py` output
+- Add `scripts/run_pipeline.sh` and wire `make pipeline` to the full ordered cycle (export-features, train, predict, `+fct_predictions`, monitor, retrain)
+- Extend GitHub Actions CI with ML checks (`py_compile`, optional model load, predict dry-run, minimum AUC with skip-if-missing)
+- Document retraining in `docs/ml_design.md`; runbook benchmarks and full flow; README portfolio overview
+
 ### Phase 8 — Monitoring (feedback loop)
 
 - Add `ml/monitor.py` — monthly ROC-AUC / precision / recall / F1 vs `fct_predictions`, overall `precision@k`, FP/FN cost from `ml/config.yaml`, ROC vs registry baseline alerts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install load-data dbt-deps dbt-build dbt-test export-features ml-train ml-predict pipeline clean
+.PHONY: install load-data dbt-deps dbt-build dbt-test export-features ml-train ml-predict ml-evaluate pipeline clean
 
 # ---------- Environment ----------
 
@@ -35,20 +35,14 @@ ml-train:
 ml-predict:
 	python ml/predict.py
 
+ml-evaluate:
+	python ml/evaluate.py
+
 # ---------- Full Pipeline ----------
+# Order: load-data → dbt-build → export-features → train → predict → fct_predictions → monitor → retrain
 
 pipeline:
-	@echo "=== Step 0: Load raw data ==="
-	$(MAKE) load-data
-	@echo "=== Step 1: dbt build ==="
-	$(MAKE) dbt-build
-	@echo "=== Step 2: ML predict ==="
-	$(MAKE) ml-predict
-	@echo "=== Step 3: ML monitor ==="
-	python ml/monitor.py
-	@echo "=== Step 4: ML retrain (if triggered) ==="
-	python ml/retrain.py
-	@echo "=== Pipeline complete ==="
+	bash scripts/run_pipeline.sh
 
 # ---------- Utilities ----------
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Olist Data Platform
 
-End-to-end data system that transforms raw e-commerce data into reliable metrics and monitored delivery-delay predictions.
+End-to-end **data + ML** platform for the **Olist Brazilian e-commerce** dataset: raw CSVs land in DuckDB, **dbt** builds staging → intermediate → marts → metrics → **`fct_order_features`**, a Parquet export feeds **scikit-learn** training and batch scoring, and **monitoring + retraining** close the loop on delivery-delay prediction (`is_delayed`).
 
 ## Tech Stack
 
@@ -17,9 +17,17 @@ End-to-end data system that transforms raw e-commerce data into reliable metrics
 ## Architecture
 
 ```
-CSV (Olist) → stg_* → int_* → fact/dim → metrics
-                                    ↓
-                              features → .parquet → train → predict → monitor → retrain
+CSV (Olist) -> DuckDB raw -> dbt (stg -> int -> marts -> metrics -> fct_order_features)
+                                    |
+                         data/ml/features.parquet
+                                    |
+ ml/train.py -> model_v*.joblib + current_model.yaml + train_v*.parquet
+                                    |
+              ml/predict.py -> ml_predictions (DuckDB) -> dbt fct_predictions
+                                    |
+              ml/monitor.py -> monitoring_*.json + drift_*.md + ml_monitoring
+                                    |
+              ml/retrain.py -> comparison_*.md + optional promotion
 ```
 
 ## Directory Structure
@@ -41,13 +49,14 @@ olist-data-platform/
 │   ├── seeds/
 │   └── tests/
 ├── ml/
-│   ├── models/           # Serialized model artifacts
+│   ├── models/           # Serialized model artifacts (*.joblib; gitignored)
 │   ├── predictions/      # Versioned prediction outputs
-│   ├── reports/          # Monitoring and evaluation reports
-│   ├── data_snapshots/   # Training data snapshots
+│   ├── reports/          # Monitoring, evaluation, comparison reports
+│   ├── data_snapshots/   # Training data snapshots (reproducibility)
+│   ├── state/            # Retrain calendar reference (optional)
 │   └── notebooks/        # EDA and analysis
 ├── docs/                 # Business definitions, ML design, runbook
-├── scripts/              # Setup, download, and utility scripts
+├── scripts/              # setup, download, load_raw_data, run_pipeline.sh, …
 ├── Makefile              # Pipeline orchestration
 ├── pyproject.toml        # Python dependencies
 └── CHANGELOG.md
@@ -56,20 +65,35 @@ olist-data-platform/
 ## Quick Start
 
 ```bash
-# 1. Set up environment
-bash scripts/setup_env.sh
+# 1. Dependencies + dbt packages (Python 3.11+)
+make install
 
-# 2. Activate venv
-source .venv/bin/activate
-
-# 3. Download Olist dataset (requires Kaggle CLI)
+# 2. Raw data (Kaggle CLI) — see scripts/download_data.sh
 bash scripts/download_data.sh
 
-# 4. Run the full pipeline
+# 3. Full cycle: load → dbt → features → train → predict → fct_predictions → monitor → retrain
 make pipeline
 ```
 
-See [docs/runbook.md](docs/runbook.md) for detailed instructions.
+On **Windows**, use **Git Bash** or **WSL** so `make pipeline` can run `bash scripts/run_pipeline.sh`. Alternatively, run the steps in [docs/runbook.md](docs/runbook.md) manually.
+
+See [docs/runbook.md](docs/runbook.md) for detailed instructions and benchmark timings.
+
+## Example: predictions vs actuals (DuckDB)
+
+After `make pipeline` (or predict + `dbt build --select +fct_predictions`):
+
+```sql
+SELECT order_date,
+       actual_is_delayed,
+       predicted_class,
+       predicted_probability,
+       model_version
+FROM fct_predictions
+WHERE actual_is_delayed IS NOT NULL
+ORDER BY order_date DESC
+LIMIT 25;
+```
 
 ## Documentation
 
@@ -91,7 +115,7 @@ See [docs/runbook.md](docs/runbook.md) for detailed instructions.
 | 6 | Model Training | `v0.7-training` |
 | 7 | Inference Pipeline | `v0.8-inference` |
 | 8 | Monitoring (Feedback Loop) | `v0.9-monitoring` |
-| 9 | Retraining (Continuous Cycle) | `v1.0.0` |
+| 9 | Retraining (continuous cycle; CI ML checks) | `v1.0.0` |
 
 ## License
 

--- a/docs/ml_design.md
+++ b/docs/ml_design.md
@@ -115,8 +115,23 @@ The Parquet file is the contract between dbt and ML. dbt owns the SQL; Python ow
 - **`ml/monitor.py`** joins **predictions to actuals** via DuckDB `fct_predictions` (requires non-null `actual_is_delayed` and `order_date`).
 - **Per calendar month:** ROC-AUC, precision, recall, F1. **Overall:** same metrics plus **precision@k** (default top10% by `predicted_probability`) and **cost-weighted** confusion counts using `false_positive_cost` / `false_negative_cost` in **`ml/config.yaml`**.
 - **Alerts:** any window (or overall) with ROC-AUC **&lt; baseline − `roc_auc_alert_delta`** flags in JSON and stdout; baseline ROC defaults to **`metrics.roc_auc_val`** in `ml/current_model.yaml`.
-- **Drift:** PSI on numeric columns vs `ml/data_snapshots/train_v1.parquet`; categorical max share-difference vs `data/ml/features.parquet`; thresholds in `ml/config.yaml` (`psi_ok_max`, `psi_warning_max`, categorical bands). Output: **`ml/reports/drift_{date}.md`**.
+- **Drift:** PSI on numeric columns vs the **baseline training snapshot** (`train_snapshot` in `current_model.yaml`, default `train_v1.parquet`); categorical max share-difference vs `data/ml/features.parquet`; thresholds in `ml/config.yaml` (`psi_ok_max`, `psi_warning_max`, categorical bands). Output: **`ml/reports/drift_{date}.md`**.
 - **Artifacts:** **`ml/reports/monitoring_{date}.json`**, DuckDB **`main.ml_monitoring`** (latest run JSON blob). Intended to run on each pipeline execution (e.g. daily batch).
+- **Full drift payload:** `monitoring_*.json` includes a **`drift`** object (PSI per numeric feature, categorical shifts) for automation — not only `drift_summary`.
+
+---
+
+## Retraining triggers (Phase 9)
+
+Retraining is driven by **`ml/retrain.py`**, which reads the **latest** `ml/reports/monitoring_*.json` (from `ml/monitor.py`) plus **`ml/config.yaml`** (`retrain` section).
+
+| Trigger | Rule |
+| --- | --- |
+| **Performance** | **ROC-AUC** in **2+ consecutive** calendar **monthly** windows is below **baseline − 0.05** (same delta as `monitoring.roc_auc_alert_delta`; baseline from registry / config). |
+| **Drift** | **3+** numeric features with **PSI ≥ 0.2** (configurable via `retrain.psi_retrain_threshold` / `psi_feature_count_trigger`). |
+| **Calendar** | **Safety net:** if **≥ N** months (`retrain.calendar_months`) have passed since the last retrain reference (`ml/state/retrain_state.json`, else `trained_on` in `current_model.yaml`), retrain is eligible. |
+
+When **any** trigger fires (or **`--force`**), the script fits a new pipeline on an **extended** training window (`retrain.extended_train_end` — train strictly before this date; validation between that date and `test_start`; **test** slice unchanged vs registry). It saves **`ml/models/model_v{N}_logreg.joblib`** and **`ml/data_snapshots/train_v{N}.parquet`**, compares **old vs new** on the **same test set**, writes **`ml/reports/comparison_{old}_vs_{new}.md`**, and updates **`ml/current_model.yaml`** **only if** the new model’s **test ROC-AUC** is **strictly higher** than the active model’s.
 
 ---
 
@@ -124,14 +139,4 @@ The Parquet file is the contract between dbt and ML. dbt owns the SQL; Python ow
 
 Model artifacts are tracked via `ml/current_model.yaml` (no MLflow or W&B):
 
-```yaml
-version: "v1"
-model_path: "ml/models/model_v1.joblib"
-trained_at: "2024-01-15T10:30:00"
-metrics:
-  f1: 0.72
-  precision: 0.68
-  recall: 0.77
-  roc_auc: 0.81
-data_snapshot: "ml/data_snapshots/features_v1.parquet"
-```
+See **`ml/current_model.yaml`** in the repo for the live schema (`version`, `path`, `train_cutoff`, `test_start`, `train_snapshot`, `metrics`, etc.).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -24,26 +24,51 @@ bash scripts/download_data.sh
 
 ## Running the Pipeline
 
-```bash
-# Full pipeline (dbt build → predict → monitor → retrain)
-make pipeline
+### One command (recommended)
 
-# Individual steps
-make dbt-build      # Build all dbt models
-make dbt-test       # Run dbt tests only
-make ml-train       # Train the ML model
-make ml-predict     # Run batch predictions
+From the repo root (bash available — **Git Bash** / **macOS** / **Linux**):
+
+```bash
+make pipeline
 ```
 
-Without `make` (from repository root, after activating the venv):
+This runs `scripts/run_pipeline.sh`, which executes in order:
+
+1. `make load-data` — CSVs from `data/raw/` into DuckDB  
+2. `make dbt-build` — full dbt project  
+3. `make export-features` — `dbt build --select "+fct_order_features"` + `scripts/export_features.py`  
+4. `make ml-train` — `ml/train.py`  
+5. `make ml-predict` — `ml/predict.py`  
+6. `dbt build --select "+fct_predictions"` — refresh the predictions mart  
+7. `python ml/monitor.py` — monitoring + drift JSON/MD  
+8. `python ml/retrain.py` — triggers, optional refit + comparison + promotion  
+
+Each major step prints a **wall-clock timing** line `(timing) …: Ns` for rough benchmarking.
+
+### Individual targets
 
 ```bash
-cd dbt_project && dbt build
-cd ..
-python scripts/export_features.py
+make dbt-build # Build all dbt models
+make dbt-test        # Run dbt tests only
+make export-features # Feature mart + Parquet export
+make ml-train        # Train the ML model
+make ml-predict      # Run batch predictions
+make ml-evaluate     # Test ROC-AUC from current_model.yaml
+```
+
+### Without `run_pipeline.sh` (manual)
+
+From repository root, after activating the venv:
+
+```bash
+make load-data
+cd dbt_project && dbt build && cd ..
+make export-features
 python ml/train.py
 python ml/predict.py
 cd dbt_project && dbt build --select "+fct_predictions"
+python ml/monitor.py
+python ml/retrain.py
 ```
 
 **Inference (Phase 7):** `python ml/predict.py` reads `ml/current_model.yaml`, loads the joblib pipeline, scores `data/ml/features.parquet`, writes `ml/predictions/predictions_{version}_{date}.parquet` and replaces DuckDB table `main.ml_predictions`. Then build `fct_predictions` so predictions join `fact_orders` in dbt.
@@ -75,7 +100,33 @@ python ml/monitor.py
 
 This reads `fct_predictions` from DuckDB (scored rows with non-null `actual_is_delayed`), computes **monthly** technical metrics, **precision@k** (top decile by default) and **cost-weighted** FP/FN totals using `ml/config.yaml`, compares ROC-AUC to the baseline in `ml/current_model.yaml` (or `monitoring.baseline_roc_auc`), writes `ml/reports/monitoring_{date}.json`, runs **drift** (PSI + categorical shifts) vs `ml/data_snapshots/train_v1.parquet` and `data/ml/features.parquet`, writes `ml/reports/drift_{date}.md`, and replaces `main.ml_monitoring` with a JSON payload snapshot.
 
-**Prerequisites:** `train_v1.parquet` (from `python ml/train.py`), current `features.parquet`, and populated `fct_predictions`.
+**Prerequisites:** training snapshot (e.g. `train_v1.parquet` from `python ml/train.py`, or the path in `train_snapshot` inside `current_model.yaml`), current `features.parquet`, and populated `fct_predictions`.
+
+## Retraining (Phase 9)
+
+After monitoring has produced at least one `ml/reports/monitoring_*.json`:
+
+```bash
+python ml/retrain.py
+```
+
+Triggers are documented in [ml_design.md](ml_design.md). Use `python ml/retrain.py --force` to refit regardless of triggers (still applies the promotion rule: **test ROC-AUC must improve** to update `current_model.yaml`).
+
+## Benchmarks (illustrative)
+
+Times vary by CPU, disk, and dataset size. The following are **typical** on a mid-range laptop after data is cached locally:
+
+| Step | Order of magnitude |
+| --- | --- |
+| `dbt build` (full project) | ~1–4 min |
+| `make export-features` | ~30–90 s (includes targeted dbt + Parquet write) |
+| `python ml/train.py` | ~5–30 s |
+| `python ml/predict.py` | ~5–20 s |
+| `dbt build --select "+fct_predictions"` | ~10–40 s |
+| `python ml/monitor.py` | ~5–30 s |
+| `python ml/retrain.py` (when triggered) | ~10–60 s |
+
+Use the `(timing) …` lines from `scripts/run_pipeline.sh` on your machine as the ground truth.
 
 ## Verifying the Setup
 

--- a/ml/config.yaml
+++ b/ml/config.yaml
@@ -25,3 +25,16 @@ drift:
   # Categorical drift: max absolute difference in category share (0–1) before feature-level alert.
   categorical_max_share_diff_alert: 0.2
   categorical_max_share_diff_warning: 0.1
+
+# Retraining triggers and extended window (Phase 9).
+retrain:
+  # Safety net: suggest retraining if no run in this many calendar months.
+  calendar_months: 3
+  # Train: ts < extended_train_end; validation: [extended_train_end, test_start); test: >= test_start from registry.
+  extended_train_end: "2018-06-01"
+  # Minimum consecutive monthly windows below (baseline − roc_auc_alert_delta) to fire performance trigger.
+  performance_consecutive_windows: 2
+  # Count numeric features with PSI >= this value as drift signal (see docs/ml_design.md).
+  psi_retrain_threshold: 0.2
+  # Minimum count of such features to fire drift trigger.
+  psi_feature_count_trigger: 3

--- a/ml/current_model.yaml
+++ b/ml/current_model.yaml
@@ -7,6 +7,7 @@ active_model:
   validation_end: "2018-06-30"
   test_start: "2018-07-01"
   features_parquet: "data/ml/features.parquet"
+  train_snapshot: "ml/data_snapshots/train_v1.parquet"
   splits:
     train_rows: 64320
     validation_rows: 19643

--- a/ml/evaluate.py
+++ b/ml/evaluate.py
@@ -1,0 +1,96 @@
+"""
+Evaluate active model on the held-out test slice from `ml/current_model.yaml`.
+
+Usage:
+    python ml/evaluate.py
+    python ml/evaluate.py --check-minimum-auc 0.55
+    python ml/evaluate.py --check-minimum-auc 0.55 --skip-if-missing
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import joblib
+import pandas as pd
+import yaml
+
+import train as train_mod
+from feature_config import TARGET, feature_columns, validate_expected_columns
+
+ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_PATH = ROOT / "ml" / "current_model.yaml"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate active model test ROC-AUC.")
+    parser.add_argument(
+        "--check-minimum-auc",
+        type=float,
+        default=None,
+        help="Exit with code 1 if test ROC-AUC is below this value.",
+    )
+    parser.add_argument(
+        "--skip-if-missing",
+        action="store_true",
+        help="Exit 0 if features, registry, or model artifact are missing (e.g. CI without artifacts).",
+    )
+    args = parser.parse_args()
+
+    features_path = ROOT / "data" / "ml" / "features.parquet"
+    if args.skip_if_missing and (
+        not features_path.is_file() or not REGISTRY_PATH.is_file()
+    ):
+        print("evaluate: skip (missing features or registry)")
+        return
+    if not REGISTRY_PATH.is_file():
+        raise FileNotFoundError(f"Missing {REGISTRY_PATH}")
+    if not features_path.is_file():
+        raise FileNotFoundError(f"Missing {features_path}")
+
+    with open(REGISTRY_PATH, encoding="utf-8") as f:
+        reg = yaml.safe_load(f) or {}
+    active = reg.get("active_model") or {}
+    model_path = ROOT / Path(str(active["path"]))
+    test_start = pd.Timestamp(str(active["test_start"]))
+
+    if args.skip_if_missing and not model_path.is_file():
+        print("evaluate: skip (model artifact missing)")
+        return
+
+    if not model_path.is_file():
+        raise FileNotFoundError(f"Model not found: {model_path}")
+
+    df = pd.read_parquet(features_path)
+    df["order_purchase_timestamp"] = pd.to_datetime(df["order_purchase_timestamp"])
+    if TARGET not in df.columns:
+        raise ValueError(f"Parquet must contain `{TARGET}`.")
+    df = df.loc[df[TARGET].notna()].copy()
+    df[TARGET] = df[TARGET].astype(int)
+
+    test_mask = df["order_purchase_timestamp"] >= test_start
+    if int(test_mask.sum()) == 0:
+        raise RuntimeError("No rows in test split; check features date range vs registry test_start.")
+
+    validate_expected_columns(list(df.columns))
+    cols = feature_columns(list(df.columns))
+    pipeline = joblib.load(model_path)
+    auc = train_mod.roc_auc_on_mask(pipeline, df, test_mask, cols, TARGET)
+    print(f"Test ROC-AUC: {auc if auc is not None else 'N/A'}")
+
+    if args.check_minimum_auc is not None:
+        if auc is None:
+            print("evaluate: cannot compare minimum AUC (single class or undefined).", file=sys.stderr)
+            sys.exit(1)
+        if auc < args.check_minimum_auc:
+            print(
+                f"evaluate: ROC-AUC {auc:.6f} < minimum {args.check_minimum_auc:.6f}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/monitor.py
+++ b/ml/monitor.py
@@ -4,7 +4,7 @@ Model monitoring: performance vs actuals (monthly), business metrics, drift vs t
 Reads:
  - DuckDB `fct_predictions` (predictions + actual_is_delayed + order_date)
   - `data/ml/features.parquet` (current feature distribution)
-  - `ml/data_snapshots/train_v1.parquet` (baseline distribution for drift)
+  - `ml/data_snapshots/train_*.parquet` (baseline for drift; default `train_v1`, or `train_snapshot` in `current_model.yaml`)
   - `ml/config.yaml` (costs, thresholds)
   - `ml/current_model.yaml` (optional baseline ROC-AUC)
 
@@ -44,8 +44,22 @@ DB_PATH = ROOT / "data" / "olist.duckdb"
 CONFIG_PATH = ROOT / "ml" / "config.yaml"
 REGISTRY_PATH = ROOT / "ml" / "current_model.yaml"
 FEATURES_PATH = ROOT / "data" / "ml" / "features.parquet"
-TRAIN_SNAPSHOT_PATH = ROOT / "ml" / "data_snapshots" / "train_v1.parquet"
+DEFAULT_TRAIN_SNAPSHOT_PATH = ROOT / "ml" / "data_snapshots" / "train_v1.parquet"
 REPORT_DIR = ROOT / "ml" / "reports"
+
+
+def _train_snapshot_path() -> Path:
+    """Baseline Parquet for drift; prefer `train_snapshot` in `ml/current_model.yaml`."""
+    if not REGISTRY_PATH.is_file():
+        return DEFAULT_TRAIN_SNAPSHOT_PATH
+    with open(REGISTRY_PATH, encoding="utf-8") as f:
+        reg = yaml.safe_load(f) or {}
+    rel = (reg.get("active_model") or {}).get("train_snapshot")
+    if rel:
+        p = ROOT / Path(rel)
+        if p.is_file():
+            return p
+    return DEFAULT_TRAIN_SNAPSHOT_PATH
 
 
 @dataclass
@@ -236,12 +250,13 @@ def _run_drift(cfg: dict[str, Any]) -> dict[str, Any]:
     cat_warn = float(drift_cfg.get("categorical_max_share_diff_warning", 0.1))
     cat_alert = float(drift_cfg.get("categorical_max_share_diff_alert", 0.2))
 
-    if not TRAIN_SNAPSHOT_PATH.is_file():
-        return {"error": f"Missing baseline snapshot {TRAIN_SNAPSHOT_PATH}"}
+    baseline_path = _train_snapshot_path()
+    if not baseline_path.is_file():
+        return {"error": f"Missing baseline snapshot {baseline_path}"}
     if not FEATURES_PATH.is_file():
         return {"error": f"Missing current features {FEATURES_PATH}"}
 
-    base_df = pd.read_parquet(TRAIN_SNAPSHOT_PATH)
+    base_df = pd.read_parquet(baseline_path)
     cur_df = pd.read_parquet(FEATURES_PATH)
 
     from feature_config import CATEGORICAL_FEATURES, NUMERIC_FEATURES
@@ -285,7 +300,7 @@ def _run_drift(cfg: dict[str, Any]) -> dict[str, Any]:
         overall = "ok"
 
     return {
-        "baseline_path": str(TRAIN_SNAPSHOT_PATH.relative_to(ROOT)),
+        "baseline_path": str(baseline_path.relative_to(ROOT)),
         "current_path": str(FEATURES_PATH.relative_to(ROOT)),
         "overall_status": overall,
         "numeric": numeric_results,
@@ -390,6 +405,7 @@ def main() -> None:
     }
 
     drift = _run_drift(cfg)
+    monitoring_payload["drift"] = drift
     monitoring_payload["drift_summary"] = {
         "overall_status": drift.get("overall_status"),
         "error": drift.get("error"),

--- a/ml/predict.py
+++ b/ml/predict.py
@@ -4,10 +4,12 @@ write versioned Parquet + DuckDB table main.ml_predictions.
 
 Usage (from repo root):
     python ml/predict.py
+    python ml/predict.py --dry-run
 """
 
 from __future__ import annotations
 
+import argparse
 from datetime import date, datetime, timezone
 from pathlib import Path
 
@@ -43,15 +45,38 @@ def _load_registry() -> dict:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Batch scoring from features Parquet.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run load + transform + predict; do not write Parquet or DuckDB.",
+    )
+    parser.add_argument(
+        "--skip-if-missing",
+        action="store_true",
+        help="Exit 0 if registry, model, or features are missing (CI without artifacts).",
+    )
+    args = parser.parse_args()
+
+    if args.skip_if_missing and not REGISTRY_PATH.is_file():
+        print("predict: skip (no registry)")
+        return
+
     active = _load_registry()
     model_rel = Path(active["path"])
     model_path = ROOT / model_rel
     if not model_path.is_file():
+        if args.skip_if_missing:
+            print("predict: skip (no model artifact)")
+            return
         raise FileNotFoundError(f"Model artifact not found: {model_path}")
 
     features_rel = Path(active["features_parquet"])
     features_path = ROOT / features_rel
     if not features_path.is_file():
+        if args.skip_if_missing:
+            print("predict: skip (no features parquet)")
+            return
         raise FileNotFoundError(
             f"Features parquet not found: {features_path}. Run export_features first."
         )
@@ -90,6 +115,12 @@ def main() -> None:
 
     if len(out) != len(df):
         raise RuntimeError("Internal error: prediction row count mismatch.")
+
+    if args.dry_run:
+        print(
+            f"dry-run OK: scored {len(out)} rows (model {version}); skipping writes."
+        )
+        return
 
     PREDICTIONS_DIR.mkdir(parents=True, exist_ok=True)
     day = date.today().isoformat()

--- a/ml/retrain.py
+++ b/ml/retrain.py
@@ -1,0 +1,415 @@
+"""
+Retraining orchestrator (Phase 9): read latest monitoring report, evaluate triggers,
+optionally retrain with an extended temporal window, compare to the active model,
+promote `ml/current_model.yaml` only if test ROC-AUC improves.
+
+Usage (repo root):
+    python ml/retrain.py
+    python ml/retrain.py --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import joblib
+import numpy as np
+import pandas as pd
+import yaml
+from sklearn.metrics import f1_score, precision_score, recall_score, roc_auc_score
+
+import train as train_mod
+from feature_config import CATEGORICAL_FEATURES, TARGET, feature_columns, validate_expected_columns
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = ROOT / "ml" / "config.yaml"
+REGISTRY_PATH = ROOT / "ml" / "current_model.yaml"
+FEATURES_PATH = ROOT / "data" / "ml" / "features.parquet"
+REPORT_DIR = ROOT / "ml" / "reports"
+STATE_PATH = ROOT / "ml" / "state" / "retrain_state.json"
+MODEL_DIR = ROOT / "ml" / "models"
+SNAPSHOT_DIR = ROOT / "ml" / "data_snapshots"
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+log = logging.getLogger("retrain")
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _latest_monitoring_json() -> Path | None:
+    paths = sorted(REPORT_DIR.glob("monitoring_*.json"))
+    return paths[-1] if paths else None
+
+
+def _parse_version(v: str) -> int:
+    s = str(v).strip().lower()
+    if s.startswith("v"):
+        s = s[1:]
+    return int(s)
+
+
+def _max_consecutive_alerts(windows: list[dict[str, Any]]) -> int:
+    """windows sorted by calendar period; count longest run of roc_auc_alert True."""
+    best = cur = 0
+    for w in windows:
+        if w.get("roc_auc_alert"):
+            cur += 1
+            best = max(best, cur)
+        else:
+            cur = 0
+    return best
+
+
+def _count_high_psi_numeric(drift: dict[str, Any], threshold: float) -> int:
+    n = 0
+    for row in drift.get("numeric", []):
+        psi = row.get("psi")
+        if isinstance(psi, (float, int)) and not (isinstance(psi, float) and np.isnan(psi)):
+            if float(psi) >= threshold:
+                n += 1
+    return n
+
+
+def _months_between(iso_a: str, iso_b: str) -> float:
+    """Approximate calendar months between date-like ISO strings (a earlier than b)."""
+    da = datetime.fromisoformat(iso_a[:10]).date()
+    db = datetime.fromisoformat(iso_b[:10]).date()
+    return (db.year - da.year) * 12 + (db.month - da.month)
+
+
+def _load_retrain_state() -> dict[str, Any]:
+    if not STATE_PATH.is_file():
+        return {}
+    with open(STATE_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _save_retrain_state(payload: dict[str, Any]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _metric_bundle(
+    pipeline: Any,
+    df: pd.DataFrame,
+    mask: pd.Series,
+    feature_cols: list[str],
+    target_col: str,
+) -> dict[str, Any]:
+    X = train_mod.prepare_features_for_sklearn(df.loc[mask], feature_cols)
+    y = df.loc[mask, target_col].astype(int)
+    proba = pipeline.predict_proba(X)[:, 1]
+    pred = pipeline.predict(X)
+    roc: float | None
+    try:
+        roc = float(roc_auc_score(y, proba)) if len(np.unique(y.to_numpy())) > 1 else None
+    except ValueError:
+        roc = None
+    return {
+        "roc_auc": roc,
+        "precision": float(precision_score(y, pred, zero_division=0)),
+        "recall": float(recall_score(y, pred, zero_division=0)),
+        "f1": float(f1_score(y, pred, zero_division=0)),
+    }
+
+
+def _write_registry(
+    *,
+    version: str,
+    model_rel: str,
+    train_snapshot_rel: str,
+    train_cutoff: str,
+    validation_end: str,
+    test_start: str,
+    n_train: int,
+    n_val: int,
+    n_test: int,
+    metrics_val: dict[str, Any],
+    metrics_test: dict[str, Any],
+) -> None:
+    trained_on = date.today().isoformat()
+    lines = [
+        "active_model:",
+        f'  version: "{version}"',
+        '  algorithm: "logistic_regression"',
+        f'  path: "{model_rel}"',
+        f'  trained_on: "{trained_on}"',
+        f'  train_cutoff: "{train_cutoff}"',
+        f'  validation_end: "{validation_end}"',
+        f'  test_start: "{test_start}"',
+        '  features_parquet: "data/ml/features.parquet"',
+        f'  train_snapshot: "{train_snapshot_rel}"',
+        "  splits:",
+        f"    train_rows: {n_train}",
+        f"    validation_rows: {n_val}",
+        f"    test_rows: {n_test}",
+        "  metrics:",
+        f"    roc_auc_val: {metrics_val['roc_auc'] if metrics_val['roc_auc'] is not None else 'null'}",
+        f"    roc_auc_test: {metrics_test['roc_auc'] if metrics_test['roc_auc'] is not None else 'null'}",
+        f"    precision_val: {metrics_val['precision']:.6f}",
+        f"    recall_val: {metrics_val['recall']:.6f}",
+        f"    f1_val: {metrics_val['f1']:.6f}",
+        f"    precision_test: {metrics_test['precision']:.6f}",
+        f"    recall_test: {metrics_test['recall']:.6f}",
+        f"    f1_test: {metrics_test['f1']:.6f}",
+    ]
+    REGISTRY_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_comparison_report(
+    path: Path,
+    old_ver: str,
+    new_ver: str,
+    old_m: dict[str, Any],
+    new_m: dict[str, Any],
+    promoted: bool,
+) -> None:
+    def row(metric: str, o: Any, n: Any) -> str:
+        if metric == "ROC-AUC":
+            o_s = f"{o:.6f}" if o is not None else "N/A"
+            n_s = f"{n:.6f}" if n is not None else "N/A"
+            if o is not None and n is not None:
+                d_s = f"{n - o:+.6f}"
+            else:
+                d_s = "N/A"
+        else:
+            o_s, n_s = f"{o:.6f}", f"{n:.6f}"
+            d_s = f"{n - o:+.6f}"
+        return f"| {metric} | {o_s} | {n_s} | {d_s} |"
+
+    body = "\n".join(
+        [
+            f"# Model comparison — {old_ver} vs {new_ver}",
+            "",
+            f"Generated: `{datetime.now(timezone.utc).isoformat()}` (UTC)",
+            "",
+            f"**Promotion:** {'yes — `current_model.yaml` updated' if promoted else 'no — kept active model'}",
+            "",
+            "## Test set (same temporal slice as registry `test_start`)",
+            "",
+            "| Metric | old | new | delta |",
+            "| --- | --- | --- | --- |",
+            row("ROC-AUC", old_m.get("roc_auc"), new_m.get("roc_auc")),
+            row("Precision", old_m["precision"], new_m["precision"]),
+            row("Recall", old_m["recall"], new_m["recall"]),
+            row("F1", old_m["f1"], new_m["f1"]),
+            "",
+            "**Rule:** promote only if new **ROC-AUC** is strictly greater than old.",
+            "",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def evaluate_triggers(
+    monitoring: dict[str, Any],
+    drift: dict[str, Any],
+    cfg: dict[str, Any],
+    last_retrain_ref_iso: str,
+) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    rcfg = cfg.get("retrain", {})
+    consec_need = int(rcfg.get("performance_consecutive_windows", 2))
+    psi_thr = float(rcfg.get("psi_retrain_threshold", 0.2))
+    psi_count_need = int(rcfg.get("psi_feature_count_trigger", 3))
+    cal_months = int(rcfg.get("calendar_months", 3))
+
+    windows = list(monitoring.get("monthly_windows") or [])
+    windows_sorted = sorted(windows, key=lambda w: str(w.get("period", "")))
+    if _max_consecutive_alerts(windows_sorted) >= consec_need:
+        reasons.append(
+            f"performance: {consec_need}+ consecutive monthly windows with roc_auc_alert "
+            "(ROC-AUC < baseline - roc_auc_alert_delta)"
+        )
+
+    if "error" not in drift:
+        hi = _count_high_psi_numeric(drift, psi_thr)
+        if hi >= psi_count_need:
+            reasons.append(f"drift: {hi} numeric features with PSI >= {psi_thr}")
+
+    today = date.today().isoformat()
+    if _months_between(last_retrain_ref_iso[:10], today) >= cal_months:
+        reasons.append(
+            f"calendar: >={cal_months} months since last retrain reference ({last_retrain_ref_iso[:10]})"
+        )
+
+    return bool(reasons), reasons
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Retrain orchestrator (Phase 9).")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Ignore trigger evaluation and retrain anyway.",
+    )
+    args = parser.parse_args()
+
+    if not CONFIG_PATH.is_file():
+        raise FileNotFoundError(f"Missing {CONFIG_PATH}")
+    cfg = _load_yaml(CONFIG_PATH)
+
+    if not REGISTRY_PATH.is_file():
+        raise FileNotFoundError(f"Missing {REGISTRY_PATH}. Run python ml/train.py first.")
+    registry = _load_yaml(REGISTRY_PATH)
+    active = registry["active_model"]
+    old_ver = str(active["version"])
+    old_path = ROOT / str(active["path"])
+
+    state = _load_retrain_state()
+    ref_iso = state.get("last_retrain_iso") or str(active.get("trained_on", "2000-01-01"))
+
+    mon_path = _latest_monitoring_json()
+    if mon_path is None or not mon_path.is_file():
+        log.warning("No monitoring JSON in %s — cannot evaluate triggers. Exiting.", REPORT_DIR)
+        if not args.force:
+            return
+        monitoring: dict[str, Any] = {}
+        drift: dict[str, Any] = {}
+    else:
+        with open(mon_path, encoding="utf-8") as f:
+            monitoring = json.load(f)
+        drift = monitoring.get("drift") or {}
+
+    triggered, reasons = evaluate_triggers(monitoring, drift, cfg, ref_iso)
+    if args.force:
+        triggered = True
+        reasons = ["--force"]
+
+    if not triggered:
+        log.info("Retrain not triggered (performance / drift / calendar). Clean exit.")
+        return
+
+    for r in reasons:
+        log.info("Trigger: %s", r)
+
+    if not FEATURES_PATH.is_file():
+        raise FileNotFoundError(f"Missing {FEATURES_PATH}. Run export-features first.")
+
+    df = pd.read_parquet(FEATURES_PATH)
+    df["order_purchase_timestamp"] = pd.to_datetime(df["order_purchase_timestamp"])
+    if TARGET not in df.columns:
+        raise ValueError(f"Parquet must contain `{TARGET}`.")
+    df = df.loc[df[TARGET].notna()].copy()
+    df[TARGET] = df[TARGET].astype(int)
+
+    rcfg = cfg.get("retrain", {})
+    ext_end = pd.Timestamp(str(rcfg.get("extended_train_end", "2018-06-01")))
+    test_start = pd.Timestamp(str(active["test_start"]))
+
+    if ext_end >= test_start:
+        raise ValueError(
+            f"retrain.extended_train_end ({ext_end.date()}) must be before test_start ({test_start.date()})."
+        )
+
+    train_mask = df["order_purchase_timestamp"] < ext_end
+    val_mask = (df["order_purchase_timestamp"] >= ext_end) & (
+        df["order_purchase_timestamp"] < test_start
+    )
+    test_mask = df["order_purchase_timestamp"] >= test_start
+
+    n_train, n_val, n_test = int(train_mask.sum()), int(val_mask.sum()), int(test_mask.sum())
+    if n_train == 0 or n_test == 0:
+        raise RuntimeError("Retrain split produced empty train or test. Check dates and Parquet range.")
+    if n_val == 0:
+        log.warning("Validation split empty (extended_train_end touches test_start). Metrics val will be weak.")
+
+    validate_expected_columns(list(df.columns))
+    feature_cols = feature_columns(list(df.columns))
+    for c in CATEGORICAL_FEATURES:
+        if c in df.columns:
+            df[c] = df[c].astype("string").fillna(pd.NA)
+
+    new_num = _parse_version(old_ver) + 1
+    new_ver = f"v{new_num}"
+    model_basename = f"model_{new_ver}_logreg.joblib"
+    model_rel = f"ml/models/{model_basename}"
+    snapshot_basename = f"train_{new_ver}.parquet"
+    snapshot_rel = f"ml/data_snapshots/{snapshot_basename}"
+
+    log.info("Fitting new model %s (train n=%s, val n=%s, test n=%s)…", new_ver, n_train, n_val, n_test)
+    new_pipeline = train_mod.fit_pipeline_on_mask(df, train_mask, feature_cols, TARGET)
+
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    out_model = ROOT / model_rel
+    train_snapshot = df.loc[train_mask].copy()
+    train_snapshot.to_parquet(SNAPSHOT_DIR / snapshot_basename, index=False)
+    joblib.dump(new_pipeline, out_model)
+    log.info("Saved model %s and training snapshot %s", out_model, snapshot_rel)
+
+    new_val_metrics = _metric_bundle(new_pipeline, df, val_mask, feature_cols, TARGET)
+    new_test_metrics = _metric_bundle(new_pipeline, df, test_mask, feature_cols, TARGET)
+
+    if not old_path.is_file():
+        log.warning("Active model artifact missing at %s — promoting new model by default.", old_path)
+        promoted = True
+        old_test_metrics = {"roc_auc": None, "precision": 0.0, "recall": 0.0, "f1": 0.0}
+    else:
+        old_pipeline = joblib.load(old_path)
+        old_test_metrics = _metric_bundle(old_pipeline, df, test_mask, feature_cols, TARGET)
+        o_roc = old_test_metrics.get("roc_auc")
+        n_roc = new_test_metrics.get("roc_auc")
+        promoted = (
+            n_roc is not None
+            and (o_roc is None or (n_roc is not None and n_roc > o_roc))
+        )
+
+    val_end_date = (test_start - pd.Timedelta(days=1)).date().isoformat()
+    comparison_path = REPORT_DIR / f"comparison_{old_ver}_vs_{new_ver}.md"
+    _write_comparison_report(
+        comparison_path,
+        old_ver,
+        new_ver,
+        old_test_metrics,
+        new_test_metrics,
+        promoted,
+    )
+    log.info("Wrote comparison report %s", comparison_path)
+
+    if promoted:
+        _write_registry(
+            version=new_ver,
+            model_rel=model_rel,
+            train_snapshot_rel=snapshot_rel,
+            train_cutoff=ext_end.date().isoformat(),
+            validation_end=val_end_date,
+            test_start=test_start.date().isoformat(),
+            n_train=n_train,
+            n_val=n_val,
+            n_test=n_test,
+            metrics_val=new_val_metrics,
+            metrics_test=new_test_metrics,
+        )
+        n_auc = new_test_metrics.get("roc_auc")
+        o_auc = old_test_metrics.get("roc_auc")
+        log.info(
+            "Promoted %s in %s (test ROC-AUC %s vs previous %s).",
+            new_ver,
+            REGISTRY_PATH,
+            f"{n_auc:.6f}" if n_auc is not None else "N/A",
+            f"{o_auc:.6f}" if o_auc is not None else "N/A",
+        )
+    else:
+        log.info(
+            "Retained active model %s (new test ROC-AUC not better: new=%s old=%s).",
+            old_ver,
+            new_test_metrics.get("roc_auc"),
+            old_test_metrics.get("roc_auc"),
+        )
+
+    state["last_retrain_iso"] = datetime.now(timezone.utc).isoformat()
+    _save_retrain_state(state)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/train.py
+++ b/ml/train.py
@@ -165,6 +165,7 @@ def _write_yaml(
         '  validation_end: "2018-06-30"',
         '  test_start: "2018-07-01"',
         '  features_parquet: "data/ml/features.parquet"',
+        '  train_snapshot: "ml/data_snapshots/train_v1.parquet"',
         "  splits:",
         f"    train_rows: {n_train}",
         f"    validation_rows: {n_val}",
@@ -269,6 +270,52 @@ Generated: `{datetime.now(timezone.utc).isoformat()}` (UTC)
 *Regenerate this file with `python ml/train.py` after updating `data/ml/features.parquet`.*
 """
     EVAL_REPORT_PATH.write_text(body, encoding="utf-8")
+
+
+def prepare_features_for_sklearn(df_sub: pd.DataFrame, feature_cols: list[str]) -> pd.DataFrame:
+    """Match inference preprocessing (numeric float64, categorical 'missing' string)."""
+    d = df_sub.loc[:, feature_cols].copy()
+    num_cols = [c for c in NUMERIC_FEATURES if c in feature_cols]
+    cat_cols = [c for c in CATEGORICAL_FEATURES if c in feature_cols]
+    for c in num_cols:
+        d[c] = pd.to_numeric(d[c], errors="coerce").astype("float64")
+    for c in cat_cols:
+        d[c] = d[c].fillna("missing").astype(str)
+    return d
+
+
+def fit_pipeline_on_mask(
+    df: pd.DataFrame,
+    train_mask: pd.Series,
+    feature_cols: list[str],
+    target_col: str,
+) -> Pipeline:
+    validate_expected_columns(list(df.columns))
+    num_cols = [c for c in NUMERIC_FEATURES if c in feature_cols]
+    cat_cols = [c for c in CATEGORICAL_FEATURES if c in feature_cols]
+    d_train = prepare_features_for_sklearn(df.loc[train_mask], feature_cols)
+    y_train = df.loc[train_mask, target_col].astype(int)
+    pipeline = _build_pipeline(num_cols, cat_cols)
+    pipeline.fit(d_train, y_train)
+    return pipeline
+
+
+def roc_auc_on_mask(
+    pipeline: Pipeline,
+    df: pd.DataFrame,
+    mask: pd.Series,
+    feature_cols: list[str],
+    target_col: str,
+) -> float | None:
+    d = prepare_features_for_sklearn(df.loc[mask], feature_cols)
+    y = df.loc[mask, target_col].astype(int).to_numpy()
+    if len(np.unique(y)) < 2:
+        return None
+    proba = pipeline.predict_proba(d)[:, 1]
+    try:
+        return float(roc_auc_score(y, proba))
+    except ValueError:
+        return None
 
 
 def main() -> None:

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Full end-to-end pipeline: raw load → dbt → features export → train → predict →
+# fct_predictions → monitor → retrain (if triggered).
+# Run from repository root: bash scripts/run_pipeline.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+step() {
+  echo ""
+  echo "=== $1 ==="
+}
+
+run_timed() {
+  local label="$1"
+  shift
+  local start end elapsed
+  start="$(date +%s)"
+  "$@"
+  end="$(date +%s)"
+  elapsed=$((end - start))
+  echo "(timing) ${label}: ${elapsed}s"
+}
+
+step "Load raw CSVs into DuckDB"
+run_timed "load-data" make load-data
+
+step "dbt build (full project)"
+run_timed "dbt-build" make dbt-build
+
+step "Export ML features Parquet"
+run_timed "export-features" make export-features
+
+step "Train baseline model"
+run_timed "ml-train" make ml-train
+
+step "Batch predictions → DuckDB ml_predictions"
+run_timed "ml-predict" make ml-predict
+
+step "dbt: refresh fct_predictions"
+run_timed "dbt-fct_predictions" bash -c 'cd dbt_project && dbt build --select "+fct_predictions"'
+
+step "Monitoring report"
+run_timed "ml-monitor" python ml/monitor.py
+
+step "Retrain (if triggers fire)"
+run_timed "ml-retrain" python ml/retrain.py
+
+echo ""
+echo "=== Pipeline complete ==="


### PR DESCRIPTION
## Summary

Implements **Phase 9 — Retraining (continuous cycle)**: trigger-based retraining, model comparison and conditional promotion via `ml/current_model.yaml`, full pipeline orchestration, ML checks in CI, and documentation updates.

Closes #27
Closes #28
Closes #29
Closes #30

*(Remove or adjust issue numbers if your repo uses different IDs.)*

## Changes

- Add `ml/retrain.py` to evaluate triggers from the latest `ml/reports/monitoring_*.json` (consecutive monthly ROC alerts, numeric PSI drift, calendar safety net), refit with an extended train window, save versioned `model_v{N}_logreg.joblib` and `train_v{N}.parquet`, write `ml/reports/comparison_{old}_vs_{new}.md`, and update `ml/current_model.yaml` only when test ROC-AUC strictly improves.
- Add `ml/evaluate.py` for test-slice evaluation and CI (`--check-minimum-auc`, `--skip-if-missing`).
- Extend `ml/predict.py` with `--dry-run` and `--skip-if-missing`.
- Extend `ml/monitor.py` to embed full `drift` in monitoring JSON and resolve drift baseline from `train_snapshot` in the registry (fallback to `train_v1.parquet`).
- Extend `ml/train.py` with shared helpers for retrain/evaluate and persist `train_snapshot` in the registry output.
- Add `retrain` settings to `ml/config.yaml`; add `scripts/run_pipeline.sh` and wire `make pipeline` to the full ordered cycle (including `export-features`, `+fct_predictions`, `monitor`, `retrain`).
- Update `.github/workflows/ci.yml` with ML validation (compile, optional model load, predict dry-run, minimum AUC with skip when artifacts are absent).
- Update `docs/ml_design.md`, `docs/runbook.md`, `README.md`, and `CHANGELOG.md`.

## Testing

- [x] `cd dbt_project && dbt build` passes *(or equivalent full build used in your environment)*
- [x] All schema tests pass (`make dbt-test` or `dbt test`)
- [x] `make pipeline` completes end-to-end *(requires bash; on Windows use Git Bash or WSL)*
- [x] Manual spot-check: `python ml/monitor.py` then `python ml/retrain.py` (or `--force`) and verify comparison report + promotion behavior

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] No future-leaking data in feature models
- [x] CHANGELOG updated (for tagged releases)